### PR TITLE
Align design system with PRD palette and typography

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,19 +1,15 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Inter } from "next/font/google";
 import "./globals.css";
 import { HubSpotTracking } from "@/components/hubspot-tracking";
 import { Header } from "@/components/header";
 import { Footer } from "@/components/footer";
 import { TawkTo } from "@/components/tawk-to";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
+const inter = Inter({
+  variable: "--font-inter",
   subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
+  display: "swap",
 });
 
 export const metadata: Metadata = {
@@ -49,10 +45,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="fr" className="scroll-smooth" suppressHydrationWarning>
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased min-h-screen flex flex-col`}
-        suppressHydrationWarning
-      >
+      <body className={`${inter.variable} antialiased min-h-screen flex flex-col`} suppressHydrationWarning>
         <HubSpotTracking />
         <TawkTo />
         <Header />

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,3 +1,6 @@
+const colors = require("tailwindcss/colors");
+const { fontFamily } = require("tailwindcss/defaultTheme");
+
 module.exports = {
   darkMode: ["class"],
   content: [
@@ -19,7 +22,7 @@ module.exports = {
       screens: {
         // MacBook Pro breakpoints
         "macbook13": "1280px",
-        "macbook14": "1440px", 
+        "macbook14": "1440px",
         "macbook15": "1680px",
       },
       colors: {
@@ -57,21 +60,26 @@ module.exports = {
           foreground: "hsl(var(--card-foreground))",
         },
         red: {
-          50: "#fef2f2",
-          100: "#fee2e2",
-          200: "#fecaca",
-          300: "#fca5a5",
-          400: "#f87171",
-          500: "#ef4444",
-          600: "#dc2626",
-          700: "#b91c1c",
-          800: "#991b1b",
-          900: "#7f1d1d",
+          ...colors.red,
+          600: "#E53E3E",
+          700: "#C53030",
+          800: "#9B2C2C",
+          900: "#742A2A",
           primary: "hsl(var(--red-primary))",
         },
         blue: {
+          ...colors.blue,
+          900: "#2D3848",
           marine: "hsl(var(--blue-marine))",
         },
+        gray: {
+          ...colors.gray,
+          600: "#818096",
+          900: "#2D3848",
+        },
+      },
+      fontFamily: {
+        sans: ["var(--font-inter)", ...fontFamily.sans],
       },
       borderRadius: {
         lg: "var(--radius)",
@@ -105,4 +113,4 @@ module.exports = {
     logs: true,
     themeRoot: ":root",
   },
-}
+};


### PR DESCRIPTION
## Summary
- adopt Inter as global font
- map Tailwind red, blue and gray scales to PRD colors

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: Unknown options: useEslintrc, extensions, resolvePluginsRelativeTo, rulePaths, ignorePath, reportUnusedDisableDirectives)*

------
https://chatgpt.com/codex/tasks/task_e_689bc88fac6883318014ac8d8cd7ac31