### PR TITLE
Fix HubSpot form embed on contact page

### DIFF
--- a/components/hubspot-form.tsx
+++ b/components/hubspot-form.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { useEffect } from 'react';
 import Script from 'next/script';
 
 interface HubSpotFormProps {

--- a/components/hubspot-simple.tsx
+++ b/components/hubspot-simple.tsx
@@ -26,7 +26,7 @@ export function HubSpotSimple() {
             portalId: "26878201",
             formId: "312a9f67-e613-4651-9690-4586646554a0",
             region: "eu1",
-            target: formRef.current
+            target: "#hubspot-form-simple",
           });
         }
         return;
@@ -47,7 +47,7 @@ export function HubSpotSimple() {
               portalId: "26878201",
               formId: "312a9f67-e613-4651-9690-4586646554a0",
               region: "eu1",
-              target: formRef.current
+              target: "#hubspot-form-simple",
             });
             clearInterval(waitForHubSpot);
           }


### PR DESCRIPTION
## Summary
- ensure HubSpot form uses container selector when creating the form to display properly
- tidy HubSpotForm component imports

## Testing
- `npm test` *(fails: Playwright Test did not expect test.describe() here; Cannot find module '@/components/ui/lazy-component'; Cannot find module '@/hooks/use-service-worker')*
- `npm run lint` *(fails: Unknown options: useEslintrc, extensions, resolvePluginsRelativeTo, rulePaths, ignorePath, reportUnusedDisableDirectives)*

------
https://chatgpt.com/codex/tasks/task_e_68a8752dbf5083319ef5f4fb1b1e6486