### PR TITLE
fix: render hubspot forms via inline script

### DIFF
--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -2,6 +2,7 @@ import { Metadata } from "next";
 // import { LineIcon } from "lineicons-react"; // Temporaire - Conflit avec Next.js 15
 // import { SecureEmail } from "@/components/secure-email";
 import WorkingFAQ from "@/components/faq-working";
+import HubspotFormInline from "@/components/hubspot-form-inline";
 
 export const metadata: Metadata = {
   title: "Contact - E2I VoIP | Experts téléphonie IP France & DOM",
@@ -82,22 +83,7 @@ export default function ContactPage() {
                   </p>
                 </div>
                 <div className="card-body p-8" data-testid="contact-form-body">
-                  <div id="hubspot-form-container" className="min-h-[400px]">
-                    <div 
-                      dangerouslySetInnerHTML={{
-                        __html: `
-                          <script charset="utf-8" type="text/javascript" src="//js-eu1.hsforms.net/forms/embed/v2.js"></script>
-                          <script>
-                            hbspt.forms.create({
-                              portalId: "26878201",
-                              formId: "312a9f67-e613-4651-9690-4586646554a0",
-                              region: "eu1"
-                            });
-                          </script>
-                        `
-                      }}
-                    />
-                  </div>
+                  <HubspotFormInline className="min-h-[400px]" />
                 </div>
               </div>
             </div>

--- a/components/hubspot-form-inline.tsx
+++ b/components/hubspot-form-inline.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+const HUBSPOT_INLINE_HTML = `
+  <script charset="utf-8" type="text/javascript" src="//js-eu1.hsforms.net/forms/embed/v2.js"></script>
+  <script>
+    hbspt.forms.create({
+      portalId: "26878201",
+      formId: "312a9f67-e613-4651-9690-4586646554a0",
+      region: "eu1"
+    });
+  </script>
+`;
+
+interface HubspotFormInlineProps {
+  className?: string;
+}
+
+export function HubspotFormInline({ className = "" }: HubspotFormInlineProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const scripts = Array.from(container.querySelectorAll("script"));
+    scripts.forEach((oldScript) => {
+      const newScript = document.createElement("script");
+      Array.from(oldScript.attributes).forEach((attr) => {
+        newScript.setAttribute(attr.name, attr.value);
+      });
+      newScript.appendChild(document.createTextNode(oldScript.innerHTML));
+      oldScript.parentNode?.replaceChild(newScript, oldScript);
+    });
+  }, []);
+
+  return (
+    <div
+      id="hubspot-form-container"
+      ref={containerRef}
+      className={className}
+      dangerouslySetInnerHTML={{ __html: HUBSPOT_INLINE_HTML }}
+      data-testid="hubspot-form-inline"
+    />
+  );
+}
+
+export default HubspotFormInline;

--- a/tests/contact-page-hubspot.test.tsx
+++ b/tests/contact-page-hubspot.test.tsx
@@ -2,13 +2,25 @@
 import { render, screen } from "@testing-library/react";
 import ContactPage from "../app/contact/page";
 
+const mockCreate = jest.fn();
+
+beforeEach(() => {
+  mockCreate.mockClear();
+  (window as any).hbspt = { forms: { create: mockCreate } };
+});
+
 describe("ContactPage HubSpot Integration", () => {
   it("should display the HubSpot form container", () => {
     render(<ContactPage />);
-    
+
     // Vérifier que le conteneur HubSpot est présent
     const hubspotContainer = document.getElementById('hubspot-form-container');
     expect(hubspotContainer).toBeInTheDocument();
+    expect(mockCreate).toHaveBeenCalledWith({
+      portalId: "26878201",
+      formId: "312a9f67-e613-4651-9690-4586646554a0",
+      region: "eu1",
+    });
   });
 
   it("should have the correct HubSpot form container", () => {

--- a/tests/playwright/hubspot-contact.spec.ts
+++ b/tests/playwright/hubspot-contact.spec.ts
@@ -13,11 +13,8 @@ test.describe('Page de Contact - Intégration HubSpot', () => {
     // Vérifier la section hero
     await expect(page.locator('h1')).toContainText('Contactez nos experts VoIP');
     
-    // Vérifier que le composant HubSpot est présent
-    await expect(page.locator('#hubspot-form-simple')).toBeVisible();
-    
-    // Vérifier le message de chargement
-    await expect(page.locator('text=Chargement du formulaire...')).toBeVisible();
+    // Vérifier que le conteneur HubSpot est présent
+    await expect(page.locator('#hubspot-form-container')).toBeVisible();
   });
 
   test('devrait charger le script HubSpot', async ({ page }) => {
@@ -27,9 +24,9 @@ test.describe('Page de Contact - Intégration HubSpot', () => {
     // Vérifier que le script HubSpot est dans le DOM
     const scriptElement = page.locator('script[src*="hsforms.net"]');
     await expect(scriptElement).toHaveCount(1);
-    
+
     // Vérifier l'URL du script
-    await expect(scriptElement).toHaveAttribute('src', 'https://js-eu1.hsforms.net/forms/embed/v2.js');
+    await expect(scriptElement).toHaveAttribute('src', /js-eu1\.hsforms\.net\/forms\/embed\/v2\.js/);
   });
 
   test('devrait afficher les informations de contact', async ({ page }) => {
@@ -68,7 +65,7 @@ test.describe('Page de Contact - Intégration HubSpot', () => {
     // Vérifier que la page se charge toujours
     await expect(page.locator('h1')).toContainText('Contactez nos experts VoIP');
     
-    // Vérifier que le composant HubSpot est toujours présent
-    await expect(page.locator('#hubspot-form-simple')).toBeVisible();
+    // Vérifier que le conteneur HubSpot est toujours présent
+    await expect(page.locator('#hubspot-form-container')).toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary
- ensure HubSpot forms execute when embedded via inline HTML
- adjust Contact page to use new inline component
- update Jest and Playwright tests for HubSpot form

## Testing
- `npm test tests/contact-page-hubspot.test.tsx`
- `npx playwright test tests/playwright/hubspot-contact.spec.ts` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68aef6e0fa1883319674655e642229c2