### PR TITLE
feat: activation de Vercel Analytics

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,6 +6,7 @@ import { Footer } from "@/components/layout/footer";
 import { SITE_URL, SITE_NAME } from "@/lib/site";
 import { JsonLd } from "@/components/seo/json-ld";
 import { organizationSchema, websiteSchema } from "@/lib/structured-data";
+import { Analytics } from "@vercel/analytics/next";
 // Police officielle E2I VoIP — Inter (cohérence avec le logo). Voir CHARTE_GRAPHIQUE.md
 const inter = Inter({
   variable: "--font-sans",
@@ -102,6 +103,7 @@ export default function RootLayout({
       >
         <LayoutClientChrome>{children}</LayoutClientChrome>
         <Footer />
+        <Analytics />
       </body>
     </html>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@radix-ui/react-dialog": "^1.0.4",
         "@radix-ui/react-select": "^1.2.2",
         "@radix-ui/react-slot": "^1.0.2",
+        "@vercel/analytics": "^2.0.1",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.0.0",
         "concurrently": "^8.2.2",
@@ -5573,6 +5574,48 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-2.0.1.tgz",
+      "integrity": "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
     },
     "node_modules/accepts": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@radix-ui/react-dialog": "^1.0.4",
     "@radix-ui/react-select": "^1.2.2",
     "@radix-ui/react-slot": "^1.0.2",
+    "@vercel/analytics": "^2.0.1",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.0.0",
     "concurrently": "^8.2.2",


### PR DESCRIPTION
## Changement

Activation de Vercel Analytics pour suivre les page views sur www.e2i-voip.com.

## Modifications

1. **`@vercel/analytics` ^2.0.1** installé
2. **`app/layout.tsx`** : import du composant `Analytics` depuis `@vercel/analytics/next`
3. **`<Analytics />`** rendu dans `<body>` après `<Footer />` — visible uniquement en production (Vercel), invisible en dev local

## Documentation Vercel

Suivi des étapes officielles :
- `npm i @vercel/analytics`
- `import { Analytics } from "@vercel/analytics/next"`
- Déployer sur Vercel → les page views sont collectées automatiquement

## Test

- [ ] Build OK (`npm run build`)
- [ ] Pas de warning d'hydratation
- [ ] Déploiement Vercel → vérifier les données dans le dashboard Analytics