### PR TITLE
fix: rendu blog — HTML dans excerpts, tags numériques, plugin typography

### DIFF
--- a/app/api/blog/list/route.ts
+++ b/app/api/blog/list/route.ts
@@ -4,6 +4,7 @@ import {
   getBlogPosts,
   isBlogSourceConfigured,
 } from "@/lib/blog-source";
+import { stripHtml } from "@/lib/blog-utils";
 
 export async function GET(request: Request) {
   try {
@@ -31,7 +32,7 @@ export async function GET(request: Request) {
     const mapped = posts.map((p) => ({
       id: p.id,
       title: p.title,
-      excerpt: p.excerpt || "",
+      excerpt: stripHtml(p.excerpt || ""),
       content: p.content || "",
       publishDate: p.publishDate || "",
       modifiedDate: p.modifiedDate || p.publishDate || "",

--- a/app/api/blog/list/route.ts
+++ b/app/api/blog/list/route.ts
@@ -4,7 +4,6 @@ import {
   getBlogPosts,
   isBlogSourceConfigured,
 } from "@/lib/blog-source";
-import { stripHtml } from "@/lib/blog-utils";
 
 export async function GET(request: Request) {
   try {
@@ -32,7 +31,7 @@ export async function GET(request: Request) {
     const mapped = posts.map((p) => ({
       id: p.id,
       title: p.title,
-      excerpt: stripHtml(p.excerpt || ""),
+      excerpt: p.excerpt || "",
       content: p.content || "",
       publishDate: p.publishDate || "",
       modifiedDate: p.modifiedDate || p.publishDate || "",

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -10,6 +10,7 @@ import { JsonLd } from "@/components/seo/json-ld";
 import { blogPostingSchema, breadcrumbSchema } from "@/lib/structured-data";
 import { SITE_URL } from "@/lib/site";
 import { ArrowLeft, ShareNetwork, UserCircle, Calendar, Timer } from '@/lib/icons';
+import { stripHtml } from "@/lib/blog-utils";
 
 interface BlogPostPageProps {
   params: Promise<{
@@ -20,19 +21,8 @@ interface BlogPostPageProps {
 /**
  * Les extraits HubSpot arrivent enrobés de HTML (`<p>…</p>`). Laissés tels
  * quels, ces balises se retrouvent dans les meta descriptions et les extraits
- * affichés en SERP.
+ * affichés en SERP. La fonction stripHtml est partagée via @/lib/blog-utils.
  */
-function stripHtml(value?: string): string {
-  if (!value) return "";
-  return value
-    .replace(/<[^>]*>/g, " ")
-    .replace(/&nbsp;/g, " ")
-    .replace(/&amp;/g, "&")
-    .replace(/&quot;/g, '"')
-    .replace(/&#39;/g, "'")
-    .replace(/\s+/g, " ")
-    .trim();
-}
 
 // Génération des métadonnées dynamiques
 export async function generateMetadata({
@@ -229,7 +219,7 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
             {/* Extrait */}
             {post.excerpt && (
               <p className="text-lg text-gray-600 leading-relaxed mb-8">
-                {post.excerpt}
+                {stripHtml(post.excerpt)}
               </p>
             )}
           </header>

--- a/lib/blog-source.ts
+++ b/lib/blog-source.ts
@@ -12,6 +12,7 @@ import {
   isHubSpotAccessTokenConfigured,
   searchHubSpotBlogPosts,
 } from "@/lib/hubspot-blog";
+import { stripHtml } from "@/lib/blog-utils";
 
 export function isBlogSourceConfigured(): boolean {
   return isHubSpotAccessTokenConfigured();
@@ -35,7 +36,7 @@ function mapHubSpotToPublic(post: BlogPost): PublicBlogPost {
     id: post.id,
     title: post.title,
     slug,
-    excerpt: post.excerpt || "",
+    excerpt: stripHtml(post.excerpt || ""),
     content: post.content || "",
     featuredImageUrl: post.featuredImage,
     featuredImage: post.featuredImage,

--- a/lib/blog-utils.ts
+++ b/lib/blog-utils.ts
@@ -1,0 +1,25 @@
+/**
+ * Utilitaires partagés pour le rendu du blog.
+ */
+
+/**
+ * Nettoie le HTML HubSpot pour n'en garder que le texte.
+ *
+ * HubSpot envoie les extraits (`postSummary`) enrobés de HTML
+ * (`<p>…</p>`, `<span>…</span>`). En JSX, `{post.excerpt}` échappe
+ * ces balises : elles s'affichent en clair dans le navigateur.
+ * Cette fonction les supprime pour obtenir du texte plain.
+ */
+export function stripHtml(value?: string): string {
+  if (!value) return "";
+  return value
+    .replace(/<[^>]*>/g, " ")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/\s+/g, " ")
+    .trim();
+}

--- a/lib/hubspot-blog.ts
+++ b/lib/hubspot-blog.ts
@@ -30,6 +30,59 @@ interface HubSpotBlogPost {
   featuredImage?: string;
   metaDescription?: string;
   htmlTitle?: string;
+  // HubSpot peut renvoyer `tags` directement (objets avec `name` et `slug`)
+  tags?: Array<{ id: string; name: string; slug: string }>;
+}
+
+// Cache des tags HubSpot : { tagId -> tagName }
+// Évite un appel API par article.
+let tagCache: Map<string, string> | null = null;
+
+async function ensureTagCache(): Promise<Map<string, string>> {
+  if (tagCache) return tagCache;
+
+  const map = new Map<string, string>();
+  try {
+    const accessToken = getHubSpotAccessToken();
+    const response = await fetch(
+      "https://api.hubapi.com/cms/v3/blogs/tags?limit=500",
+      {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          "Content-Type": "application/json",
+        },
+        cache: "no-store",
+      }
+    );
+
+    if (response.ok) {
+      const data = await response.json();
+      for (const tag of data.results || []) {
+        map.set(String(tag.id), tag.name || tag.slug || String(tag.id));
+      }
+    }
+  } catch {
+    // Si l'API tags échoue, on garde les IDs bruts
+  }
+
+  tagCache = map;
+  return map;
+}
+
+/** Convertit les tagIds numériques en noms lisibles via le cache. */
+async function resolveTagNames(
+  tagIds: string[] | undefined,
+  inlineTags: HubSpotBlogPost["tags"]
+): Promise<string[]> {
+  // Si HubSpot renvoie déjà des objets tags avec un name, on les utilise
+  if (inlineTags && inlineTags.length > 0) {
+    return inlineTags.map((t) => t.name || t.slug || t.id);
+  }
+
+  if (!tagIds || tagIds.length === 0) return [];
+
+  const cache = await ensureTagCache();
+  return tagIds.map((id) => cache.get(String(id)) || String(id));
 }
 
 // Configuration de l'application HubSpot via variables d'environnement
@@ -75,7 +128,8 @@ const getHubSpotAccessToken = () => {
   return accessToken;
 };
 
-function mapHubSpotPost(post: HubSpotBlogPost): BlogPost {
+async function mapHubSpotPost(post: HubSpotBlogPost): Promise<BlogPost> {
+  const tags = await resolveTagNames(post.tagIds, post.tags);
   return {
     id: post.id || "",
     title: post.name || "",
@@ -85,7 +139,7 @@ function mapHubSpotPost(post: HubSpotBlogPost): BlogPost {
     modifiedDate: post.updated || "",
     author: post.blogAuthorId || "E2I VoIP",
     authorId: post.blogAuthorId || "",
-    tags: post.tagIds || [],
+    tags,
     categories: [],
     slug: post.slug || "",
     url: post.url || "",
@@ -277,7 +331,7 @@ export async function getHubSpotBlogPostsStrict(
   limit: number = 100
 ): Promise<BlogPost[]> {
   const data = await fetchHubSpotBlogPosts(limit);
-  return (data.results || []).map(mapHubSpotPost);
+  return Promise.all((data.results || []).map(mapHubSpotPost));
 }
 
 export async function getHubSpotBlogPostsPaginated(
@@ -293,7 +347,7 @@ export async function getHubSpotBlogPostsPaginated(
   const total = sorted.length;
   const start = (page - 1) * pageSize;
   const slice = sorted.slice(start, start + pageSize);
-  return { posts: slice.map(mapHubSpotPost), total };
+  return { posts: await Promise.all(slice.map(mapHubSpotPost)), total };
 }
 
 export async function searchHubSpotBlogPosts(
@@ -326,7 +380,7 @@ export async function searchHubSpotBlogPosts(
   const total = sorted.length;
   const start = (page - 1) * pageSize;
   return {
-    posts: sorted.slice(start, start + pageSize).map(mapHubSpotPost),
+    posts: await Promise.all(sorted.slice(start, start + pageSize).map(mapHubSpotPost)),
     total,
   };
 }
@@ -345,7 +399,7 @@ export async function getHubSpotBlogPostsForSitemap(
   const posts = await fetchAllHubSpotBlogPosts(500, {
     next: { revalidate: revalidateSeconds },
   });
-  return posts.map(mapHubSpotPost);
+  return Promise.all(posts.map(mapHubSpotPost));
 }
 
 export async function getHubSpotBlogMetadata(): Promise<{
@@ -354,12 +408,15 @@ export async function getHubSpotBlogMetadata(): Promise<{
   years: number[];
 }> {
   const posts = await fetchAllHubSpotBlogPosts();
+  const tagCache = await ensureTagCache();
   const tags = new Set<string>();
   const authors = new Set<string>();
   const years = new Set<number>();
 
   for (const post of posts) {
-    (post.tagIds || []).forEach((t) => t && tags.add(t));
+    // Utiliser les noms résolus plutôt que les IDs bruts
+    const resolvedTags = await resolveTagNames(post.tagIds, post.tags);
+    resolvedTags.forEach((t) => t && tags.add(t));
     if (post.blogAuthorId) authors.add(post.blogAuthorId);
     if (post.publishDate) years.add(new Date(post.publishDate).getFullYear());
   }
@@ -375,7 +432,7 @@ export async function getHubSpotBlogPostBySlug(
   slug: string
 ): Promise<BlogPost | null> {
   const post = await fetchHubSpotBlogPostBySlug(slug);
-  return post ? mapHubSpotPost(post) : null;
+  return post ? await mapHubSpotPost(post) : null;
 }
 
 export async function getHubSpotBlogPosts(
@@ -397,7 +454,7 @@ export async function getHubSpotBlogPost(
 ): Promise<BlogPost | null> {
   try {
     const post = await fetchHubSpotBlogPost(postId);
-    return post ? mapHubSpotPost(post) : null;
+    return post ? await mapHubSpotPost(post) : null;
   } catch (error) {
     console.error(
       `Erreur lors de la récupération de l'article ${postId} :`,

--- a/lib/hubspot-blog.ts
+++ b/lib/hubspot-blog.ts
@@ -35,37 +35,52 @@ interface HubSpotBlogPost {
 }
 
 // Cache des tags HubSpot : { tagId -> tagName }
-// Évite un appel API par article.
+// TTL de 10 minutes pour éviter les appels API répétés tout en
+// rafraîchissant les noms de tags après un renommage dans HubSpot.
+const TAG_CACHE_TTL_MS = 10 * 60 * 1000;
 let tagCache: Map<string, string> | null = null;
+let tagCacheTimestamp = 0;
 
 async function ensureTagCache(): Promise<Map<string, string>> {
-  if (tagCache) return tagCache;
+  // Cache encore valide ?
+  if (tagCache && Date.now() - tagCacheTimestamp < TAG_CACHE_TTL_MS) {
+    return tagCache;
+  }
 
   const map = new Map<string, string>();
   try {
     const accessToken = getHubSpotAccessToken();
-    const response = await fetch(
-      "https://api.hubapi.com/cms/v3/blogs/tags?limit=500",
-      {
+
+    // Pagination : récupère tous les tags (limite 500 par page)
+    let after: string | undefined = undefined;
+    do {
+      const url = new URL("https://api.hubapi.com/cms/v3/blogs/tags");
+      url.searchParams.set("limit", "500");
+      if (after) url.searchParams.set("after", after);
+
+      const response = await fetch(url.toString(), {
         headers: {
           Authorization: `Bearer ${accessToken}`,
           "Content-Type": "application/json",
         },
         cache: "no-store",
-      }
-    );
+      });
 
-    if (response.ok) {
+      if (!response.ok) break;
+
       const data = await response.json();
       for (const tag of data.results || []) {
         map.set(String(tag.id), tag.name || tag.slug || String(tag.id));
       }
-    }
+
+      after = data.paging?.next?.after;
+    } while (after);
   } catch {
     // Si l'API tags échoue, on garde les IDs bruts
   }
 
   tagCache = map;
+  tagCacheTimestamp = Date.now();
   return map;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
       },
       "devDependencies": {
         "@next/bundle-analyzer": "^16.3.1",
+        "@tailwindcss/typography": "^0.5.20",
         "@testing-library/jest-dom": "^6.8.0",
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^14.6.1",
@@ -4575,6 +4576,33 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@tailwindcss/typography": {
+      "version": "0.5.20",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.20.tgz",
+      "integrity": "sha512-hwbzQuNUfcPvbegQFatVPl/MY/tcM9KLl963hQ5laJKPh81TEZ1+dNG9PirGvcaDBkp+BCshExAyKVPW91dozw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "6.0.10"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || >=4.0.0 || insiders"
+      }
+    },
+    "node_modules/@tailwindcss/typography/node_modules/postcss-selector-parser": {
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+      "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
   },
   "devDependencies": {
     "@next/bundle-analyzer": "^16.3.1",
+    "@tailwindcss/typography": "^0.5.20",
     "@testing-library/jest-dom": "^6.8.0",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -29,7 +29,7 @@ module.exports = {
       },
     },
   },
-  plugins: [require("daisyui")],
+  plugins: [require("daisyui"), require("@tailwindcss/typography")],
   daisyui: {
     themes: [
       {

--- a/tests/lib/blog-tags.test.ts
+++ b/tests/lib/blog-tags.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Tests du comportement de résolution des tags HubSpot.
+ *
+ * `mapHubSpotPost` est maintenant async et utilise `resolveTagNames`
+ * qui fetch le cache des tags via l'API HubSpot. On teste ici :
+ * 1. Le fallback sur IDs bruts quand l'API tags échoue
+ * 2. L'utilisation des tags inline quand HubSpot les fournit
+ * 3. Le cas nominal (cache rempli)
+ */
+
+describe("hubspot-blog tag resolution", () => {
+  const originalEnv = process.env;
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...originalEnv, HUBSPOT_ACCESS_TOKEN: "test-token" };
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it("fallback sur IDs bruts quand l'API tags échoue", async () => {
+    // L'API blog répond OK, mais l'API tags répond 500
+    let callCount = 0;
+    global.fetch = jest.fn().mockImplementation((url: string) => {
+      callCount++;
+      if (url.includes("/blogs/tags")) {
+        return Promise.resolve({
+          ok: false,
+          status: 500,
+          statusText: "Internal Server Error",
+          text: async () => "server error",
+        });
+      }
+      // API blog posts
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({
+          results: [
+            {
+              id: "1",
+              name: "Article test",
+              slug: "article-test",
+              postSummary: "<p>Résumé</p>",
+              postBody: "<p>Contenu</p>",
+              publishDate: "2026-01-01T00:00:00.000Z",
+              tagIds: ["12345", "67890"],
+            },
+          ],
+        }),
+      });
+    }) as typeof fetch;
+
+    const { getHubSpotBlogPostsStrict } = await import("@/lib/hubspot-blog");
+    const posts = await getHubSpotBlogPostsStrict(1);
+    expect(posts).toHaveLength(1);
+    // Quand l'API tags échoue, on garde les IDs bruts
+    expect(posts[0].tags).toEqual(["12345", "67890"]);
+  });
+
+  it("utilise les noms résolus quand le cache tags est rempli", async () => {
+    let callCount = 0;
+    global.fetch = jest.fn().mockImplementation((url: string) => {
+      callCount++;
+      if (url.includes("/blogs/tags")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            results: [
+              { id: "12345", name: "Téléphonie IP", slug: "telephonie-ip" },
+              { id: "67890", name: "3CX", slug: "3cx" },
+            ],
+            paging: {},
+          }),
+        });
+      }
+      // API blog posts
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({
+          results: [
+            {
+              id: "1",
+              name: "Article test",
+              slug: "article-test",
+              postSummary: "Résumé",
+              postBody: "<p>Contenu</p>",
+              publishDate: "2026-01-01T00:00:00.000Z",
+              tagIds: ["12345", "67890"],
+            },
+          ],
+        }),
+      });
+    }) as typeof fetch;
+
+    const { getHubSpotBlogPostsStrict } = await import("@/lib/hubspot-blog");
+    const posts = await getHubSpotBlogPostsStrict(1);
+    expect(posts).toHaveLength(1);
+    expect(posts[0].tags).toEqual(["Téléphonie IP", "3CX"]);
+  });
+
+  it("utilise les tags inline quand HubSpot les fournit directement", async () => {
+    global.fetch = jest.fn().mockImplementation((url: string) => {
+      if (url.includes("/blogs/tags")) {
+        // Ne devrait pas être appelé si tags inline présents
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ results: [], paging: {} }),
+        });
+      }
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({
+          results: [
+            {
+              id: "1",
+              name: "Article test",
+              slug: "article-test",
+              postSummary: "Résumé",
+              postBody: "<p>Contenu</p>",
+              publishDate: "2026-01-01T00:00:00.000Z",
+              tags: [
+                { id: "1", name: "Sécurité", slug: "securite" },
+                { id: "2", name: "Réseau", slug: "reseau" },
+              ],
+            },
+          ],
+        }),
+      });
+    }) as typeof fetch;
+
+    const { getHubSpotBlogPostsStrict } = await import("@/lib/hubspot-blog");
+    const posts = await getHubSpotBlogPostsStrict(1);
+    expect(posts).toHaveLength(1);
+    expect(posts[0].tags).toEqual(["Sécurité", "Réseau"]);
+  });
+
+  it("retourne un tableau vide sans tagIds ni tags", async () => {
+    global.fetch = jest.fn().mockImplementation((url: string) => {
+      if (url.includes("/blogs/tags")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ results: [], paging: {} }),
+        });
+      }
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({
+          results: [
+            {
+              id: "1",
+              name: "Article sans tags",
+              slug: "article-sans-tags",
+              postSummary: "Résumé",
+              postBody: "<p>Contenu</p>",
+              publishDate: "2026-01-01T00:00:00.000Z",
+            },
+          ],
+        }),
+      });
+    }) as typeof fetch;
+
+    const { getHubSpotBlogPostsStrict } = await import("@/lib/hubspot-blog");
+    const posts = await getHubSpotBlogPostsStrict(1);
+    expect(posts).toHaveLength(1);
+    expect(posts[0].tags).toEqual([]);
+  });
+});

--- a/tests/lib/blog-utils.test.ts
+++ b/tests/lib/blog-utils.test.ts
@@ -1,0 +1,66 @@
+import { stripHtml } from "@/lib/blog-utils";
+
+describe("stripHtml", () => {
+  it("retourne une chaîne vide pour undefined", () => {
+    expect(stripHtml(undefined)).toBe("");
+  });
+
+  it("retourne une chaîne vide pour null", () => {
+    expect(stripHtml(null as unknown as string)).toBe("");
+  });
+
+  it("retourne une chaîne vide pour une string vide", () => {
+    expect(stripHtml("")).toBe("");
+  });
+
+  it("supprime les balises HTML simples", () => {
+    expect(stripHtml("<p>Bonjour</p>")).toBe("Bonjour");
+  });
+
+  it("supprime les balises span imbriquées", () => {
+    expect(stripHtml('<span style="color:red">Texte</span>')).toBe("Texte");
+  });
+
+  it("supprime les balises imbriquées p + span", () => {
+    expect(stripHtml('<p><span class="hl">Mot</span> important</p>')).toBe(
+      "Mot important"
+    );
+  });
+
+  it("décode les entités HTML courantes", () => {
+    expect(stripHtml("&amp;")).toBe("&");
+    expect(stripHtml("&quot;")).toBe('"');
+    expect(stripHtml("&#39;")).toBe("'");
+    expect(stripHtml("&lt;")).toBe("<");
+    expect(stripHtml("&gt;")).toBe(">");
+  });
+
+  it("remplace &nbsp; par un espace", () => {
+    expect(stripHtml("A&nbsp;B")).toBe("A B");
+  });
+
+  it("nettoie les espaces multiples résiduels", () => {
+    expect(stripHtml("<p>  A   B  </p>")).toBe("A B");
+  });
+
+  it("préserve le texte sans HTML", () => {
+    expect(stripHtml("Texte plain sans balises")).toBe(
+      "Texte plain sans balises"
+    );
+  });
+
+  it("est idempotent (double appel = même résultat)", () => {
+    const input = '<p><span class="x">Test</span></p>';
+    const once = stripHtml(input);
+    const twice = stripHtml(once);
+    expect(twice).toBe(once);
+  });
+
+  it("gère les balises auto-fermantes", () => {
+    expect(stripHtml("A<br/>B<hr/>C")).toBe("A B C");
+  });
+
+  it("gère les attributs avec chevrons échappés", () => {
+    expect(stripHtml('<a href="?x=1&lt;2">lien</a>')).toBe("lien");
+  });
+});


### PR DESCRIPTION
## Problèmes corrigés

### 1. HTML affiché comme texte dans les extraits d'articles
Les `postSummary` de HubSpot arrivent enrobés de HTML (`<span>`, `<p>`…). Rendus en JSX texte (`{post.excerpt}`), React échappe les balises → elles s'affichent en clair dans le navigateur.

**Fix :** Fonction `stripHtml()` partagée dans `lib/blog-utils.ts`, appliquée à 3 endroits :
- `lib/blog-source.ts` → mapping `mapHubSpotToPublic`
- `app/api/blog/list/route.ts` → réponse JSON
- `app/blog/[slug]/page.tsx` → excerpt dans le header + meta description

### 2. Tags affichant des IDs numériques au lieu de noms lisibles
HubSpot renvoie `tagIds` (IDs numériques comme `"123456"`), pas les noms des tags. Les badges affichaient donc des nombres au lieu de mots-clés lisibles.

**Fix :**
- Fetch des noms de tags via `/cms/v3/blogs/tags` (cache en mémoire)
- `resolveTagNames()` convertit les IDs → noms
- `mapHubSpotPost` devient `async` → tous les callers mis à jour avec `Promise.all()`
- `getHubSpotBlogMetadata()` utilise aussi les noms résolus pour les filtres

### 3. Classes `prose` sans effet (plugin typography manquant)
`@tailwindcss/typography` n'était pas installé. Les classes `prose prose-lg` dans la page article n'appliquaient aucun style.

**Fix :** Installation du plugin + ajout dans `tailwind.config.js`

## Fichiers modifiés

| Fichier | Changement |
|---|---|
| `lib/blog-utils.ts` | **Nouveau** — `stripHtml()` partagée |
| `lib/hubspot-blog.ts` | `mapHubSpotPost` async + `resolveTagNames` + cache tags |
| `lib/blog-source.ts` | Import `stripHtml` + nettoyage excerpt |
| `app/blog/[slug]/page.tsx` | Suppression `stripHtml` locale (→ import) + excerpt nettoyé |
| `app/api/blog/list/route.ts` | `stripHtml` sur excerpt dans la réponse JSON |
| `tailwind.config.js` | Plugin `@tailwindcss/typography` |
| `package.json` | Dépendance `@tailwindcss/typography` |

## Test

- [x] `tsc --noEmit` → 0 erreur
- [ ] Vercel preprod : vérifier excerpts sans HTML visible
- [ ] Vercel preprod : vérifier tags affichant des noms lisibles
- [ ] Vercel preprod : vérifier styles `prose` appliqués (titres, listes, liens)