### PR TITLE
docs(agents): imposer la livraison par Pull Request vers dev

### DIFF
--- a/.agents.md
+++ b/.agents.md
@@ -91,7 +91,28 @@ Guide dédié aux assistants IA pour le développement du projet E2I VoIP avec N
 2. **GREEN**: Implement minimal code to pass test
 3. **REFACTOR**: Optimize while keeping tests green
 4. **DOCUMENT**: Update documentation automatically
-5. **COMMIT & PUSH**: After complete test validation
+5. **COMMIT & PR**: après validation complète des tests — commit sur une branche dédiée, puis Pull Request vers `dev` (voir « Livraison par Pull Request »)
+
+## 🔀 Livraison par Pull Request (RÈGLE ABSOLUE)
+
+**Toute modification du site passe obligatoirement par une Pull Request GitHub. Aucun commit direct sur `dev` ni sur `main`.**
+
+Flux imposé : `branche dédiée` → **PR vers `dev`** → relecture et merge par Alban → `dev` → `main` (opération manuelle déclenchée par Alban).
+
+```bash
+git switch dev && git pull
+git switch -c feat/<sujet-court>     # feat/ fix/ chore/ docs/ refactor/ test/
+# ... développement + tests ...
+npm run validate                      # 6 contrôles — bloquer si 1 échoue
+git push -u origin feat/<sujet-court>
+gh pr create --base dev --title "<titre>" --body "<corps>"
+```
+
+Corps de PR attendu : objectif, liste des changements, résultat des tests (Jest + Playwright), entrée ADR associée, points de vigilance.
+
+**Interdictions strictes pour l'agent** : ne jamais merger une PR (`--merge`, `--squash`, `--admin`, `--auto`) ; ne jamais pousser directement sur `dev` ou `main` ; ne jamais fusionner `dev` dans `main` ; ne jamais `--force` sur une branche partagée. Livrer l'URL de la PR puis s'arrêter.
+
+**Seule exception** : demande explicite d'Alban pour une intervention donnée — valable pour celle-ci uniquement.
 
 ### Test Commands
 

--- a/agents.md
+++ b/agents.md
@@ -15,7 +15,32 @@
 6. Vérifier l'hydratation CSS (aucun warning/erreur au lancement du serveur de développement).
 7. Documenter l'évolution dans `docs/ADR.md` (nouvelle décision, impacts, tests).
 8. Mettre à jour la roadmap et le plan d'implémentation.
-9. Quand tout est vert et que l'ADR est à jour : commit, puis push vers GitHub.
+9. Quand tout est vert et que l'ADR est à jour : commit sur une branche dédiée, puis **ouvrir une PR GitHub vers `dev`** (voir « Livraison par Pull Request »).
+
+## Livraison par Pull Request (RÈGLE ABSOLUE)
+
+**Toute modification du site passe obligatoirement par une Pull Request GitHub. Aucun commit direct sur `dev` ni sur `main`.**
+
+Flux imposé : `branche dédiée` → **PR vers `dev`** → relecture et merge par Alban → `dev` → `main` (opération manuelle déclenchée par Alban).
+
+1. Créer une branche dédiée depuis `dev` à jour :
+   `git switch dev && git pull && git switch -c <type>/<sujet-court>`
+   Préfixes : `feat/`, `fix/`, `chore/`, `docs/`, `refactor/`, `test/`.
+2. Committer le travail sur cette branche (messages en français, format Conventional Commits).
+3. `npm run validate` doit passer — **6 contrôles, bloquer si un seul échoue**.
+4. Pousser et ouvrir la PR ciblant `dev` :
+   `git push -u origin <branche>`
+   `gh pr create --base dev --title "<titre>" --body "<corps>"`
+5. Le corps de PR doit contenir : objectif, liste des changements, résultat des tests (Jest + Playwright), entrée ADR associée, points de vigilance / risques.
+6. Rendre la main à Alban avec l'URL de la PR, puis **s'arrêter**.
+
+**Interdictions strictes pour l'agent** :
+- Ne jamais merger une PR (ni `--merge`, ni `--squash`, ni `--admin`, ni `--auto`).
+- Ne jamais pousser sur `dev` ou `main` directement, même pour un « petit » correctif.
+- Ne jamais fusionner `dev` dans `main` : c'est une décision d'Alban.
+- Ne jamais forcer un push (`--force`) sur une branche partagée.
+
+**Seule exception** : si Alban demande explicitement un commit direct sur `dev` ou `main` pour une intervention donnée. L'exception vaut pour cette intervention uniquement, jamais pour les suivantes.
 
 ## Validation Rapide
 

--- a/claude.md
+++ b/claude.md
@@ -25,7 +25,8 @@ L'essentiel : chef de projet, dev NextJS débutant. Réponses courtes, **une cho
 2. Hero gradient : `bg-gradient-to-r from-blue-900/85 via-blue-800/80 to-red-600/85`
 3. Charte (`CHARTE_GRAPHIQUE.md`, `.docx`, `BrandBrief`) : permission requise pour modifier
 4. Pre-push : `npm run validate` obligatoire (6 contrôles — bloquer si 1 échoue)
-5. TDD : RED → GREEN → REFACTOR → DOCUMENT → COMMIT
+5. TDD : RED → GREEN → REFACTOR → DOCUMENT → COMMIT → PR
+6. **Pull Request obligatoire** : toute modif passe par une branche dédiée → PR vers `dev` (`gh pr create --base dev`). Jamais de commit direct sur `dev` ou `main`, jamais de merge par l'agent. `dev → main` est déclenché par Alban. Détail : `agents.md` § « Livraison par Pull Request »
 
 ## Permissions
 


### PR DESCRIPTION
## Objectif

Inscrire dans les fichiers de consignes que **toute modification du site passe obligatoirement par une Pull Request GitHub** ciblant `dev`. Les commits directs sur `dev` et `main` sont interdits, et l'agent ne merge jamais.

Flux imposé : `branche dédiée` → **PR vers `dev`** → relecture et merge par Alban → `dev` → `main` (déclenché par Alban).

## Changements

- **`agents.md`** — nouvelle section « Livraison par Pull Request (RÈGLE ABSOLUE) » : flux en 6 étapes, commandes `git`/`gh`, contenu attendu du corps de PR, et 4 interdictions explicites (merger une PR, pousser sur `dev`/`main`, fusionner `dev → main`, `--force` sur branche partagée). L'étape 9 du « Processus Fonctionnalité » passe de « commit, puis push » à « commit sur une branche dédiée, puis PR ».
- **`.agents.md`** — même règle en version condensée avec bloc de commandes. L'étape 5 du cycle TDD passe de `COMMIT & PUSH` à `COMMIT & PR`.
- **`claude.md`** — règle absolue n°6 renvoyant vers `agents.md` ; cycle TDD complété par l'étape PR.

Les trois anciennes formulations « commit puis push » ont été remplacées **sur place, au point de décision**, plutôt que de simplement ajouter un bloc en fin de fichier : un agent qui lit le cycle TDD tombe désormais sur la nouvelle consigne, pas sur l'ancienne.

Une exception est prévue : demande explicite d'Alban, valable pour l'intervention concernée uniquement.

## Tests

Aucun test exécuté — PR **documentaire uniquement**, aucun fichier applicatif touché (`agents.md`, `.agents.md`, `claude.md`). Aucun impact sur le build, le runtime ou les suites Jest/Playwright.

## ADR

Pas d'entrée ADR créée : il s'agit d'une règle de process de contribution, pas d'une décision d'architecture technique. À me dire si tu préfères qu'elle soit tracée dans `docs/ADR.md`.

## Points de vigilance

⚠️ **Ces fichiers sont déclaratifs, pas contraignants.** Rien n'empêche techniquement un agent (ou un humain) de pousser sur `dev`. La garantie réelle demande une **branch protection rule** GitHub sur `dev` et `main`, qui rejette le push côté serveur. Non fait dans cette PR — à activer séparément.

ℹ️ Le repo contient deux fichiers de consignes (`agents.md` et `.agents.md`). Sur macOS, le système de fichiers étant insensible à la casse, `agents.md` est celui que les outils cherchant `AGENTS.md` chargent réellement ; `.agents.md` n'est lu que parce que `claude.md` le référence. La règle a été mise dans les deux pour cette raison.

🤖 Generated with [Claude Code](https://claude.com/claude-code)