### PR TITLE
fix: centrage du logo E2I en fin d'article de blog

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -75,6 +75,16 @@
   }
 }
 
+/* Centrer les images isolées dans le contenu des articles de blog.
+   HubSpot insère le logo E2I en fin d'article dans un <img> standalone
+   (hors paragraphe) qui n'est pas centré par défaut par Tailwind Typography. */
+.prose img[alt*="E2I"],
+.prose img[src*="e2ivoip-logo"] {
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+}
+
 @layer utilities {
   /* Animation de vibration pour le bouton chat */
   @keyframes shake {


### PR DESCRIPTION
## Problème

Le logo E2I inséré par HubSpot en fin d'article n'est pas centré — il s'affiche aligné à gauche dans le contenu `prose`.

## Cause

HubSpot insère un `<img>` standalone avec `alt="E2I VOIP"` et `src="...e2ivoip-logo-transparent-solo.png"`. Tailwind Typography (`.prose`) aligne les images à gauche par défaut.

## Fix

Règle CSS dans `globals.css` qui cible les images avec `alt` contenant "E2I" ou `src` contenant "e2ivoip-logo" et les centre avec `margin: auto`.

```css
.prose img[alt*="E2I"],
.prose img[src*="e2ivoip-logo"] {
  display: block;
  margin-left: auto;
  margin-right: auto;
}
```

## Test

- `tsc --noEmit` → 0 erreur
- Vérification Playwright du rendu en prod après déploiement