### PR TITLE
feat(legal): renforcer les pages légales et ouvrir l'exercice des droits RGPD

### DIFF
--- a/app/api/rgpd/demande/route.ts
+++ b/app/api/rgpd/demande/route.ts
@@ -1,0 +1,245 @@
+import { NextResponse } from "next/server";
+import { Resend } from "resend";
+import { checkRateLimit, getClientIdentifier } from "@/lib/api/rate-limit";
+import {
+  sanitize,
+  escapeHtml,
+  escapeHtmlMultiline,
+  isValidEmail,
+  sanitizeHeader,
+} from "@/lib/api/email-safety";
+import { RGPD_RIGHTS, getRightById, type RgpdRight } from "@/lib/rgpd/rights";
+
+/**
+ * Réception des demandes d'exercice de droits RGPD.
+ *
+ * Deux envois de statut différent :
+ *  - la notification interne est bloquante — si elle échoue, la demande n'a
+ *    atteint personne et le visiteur doit le savoir pour recommencer ;
+ *  - l'accusé de réception au demandeur est best-effort — son échec ne doit
+ *    pas laisser croire que la demande est perdue alors qu'elle est arrivée.
+ */
+
+// Une demande d'exercice de droits est un acte rare : un quota serré suffit
+// et limite l'usage de la route comme relais d'emails.
+const RATE_LIMIT_MAX = 3;
+const RATE_LIMIT_WINDOW_MS = 15 * 60 * 1000;
+
+const DELAI_LEGAL = "un mois";
+
+function requireEnv(name: string): string {
+  const v = process.env[name];
+  if (!v) throw new Error(`${name} is required`);
+  return v;
+}
+
+const FIELD_LIMITS = {
+  firstName: 100,
+  lastName: 100,
+  email: 254, // RFC 5321
+  phone: 30,
+  details: 2000,
+  pageUrl: 500,
+} as const;
+
+/** Nombre maximum d'identifiants de droits acceptés dans un envoi. */
+const MAX_REQUEST_TYPES = RGPD_RIGHTS.length;
+
+export interface RgpdDemandePayload {
+  firstName: string;
+  lastName: string;
+  email: string;
+  phone?: string;
+  requestTypes: string[];
+  details?: string;
+  pageUrl?: string;
+}
+
+/**
+ * Convertit les identifiants reçus en droits connus.
+ * Retourne `null` dès qu'un identifiant est inconnu : mieux vaut refuser la
+ * demande que d'en traiter une version amputée à l'insu du demandeur.
+ */
+function resolveRights(value: unknown): RgpdRight[] | null {
+  if (!Array.isArray(value) || value.length === 0) return null;
+  if (value.length > MAX_REQUEST_TYPES) return null;
+
+  const rights: RgpdRight[] = [];
+  for (const id of value) {
+    if (typeof id !== "string") return null;
+    const right = getRightById(id.trim());
+    if (!right) return null;
+    if (!rights.includes(right)) rights.push(right);
+  }
+  return rights;
+}
+
+export async function POST(request: Request) {
+  try {
+    const { allowed, retryAfter } = checkRateLimit(
+      getClientIdentifier(request),
+      RATE_LIMIT_MAX,
+      RATE_LIMIT_WINDOW_MS
+    );
+    if (!allowed) {
+      return NextResponse.json(
+        { error: "Trop de demandes. Réessayez dans quelques minutes." },
+        { status: 429, headers: { "Retry-After": String(retryAfter) } }
+      );
+    }
+
+    const body = (await request.json()) as Partial<RgpdDemandePayload>;
+
+    const firstName = sanitize(body.firstName, FIELD_LIMITS.firstName);
+    const lastName = sanitize(body.lastName, FIELD_LIMITS.lastName);
+    const email = sanitize(body.email, FIELD_LIMITS.email);
+    const phone = sanitize(body.phone, FIELD_LIMITS.phone);
+    const details = sanitize(body.details, FIELD_LIMITS.details);
+    const pageUrl = sanitize(body.pageUrl, FIELD_LIMITS.pageUrl);
+
+    if (!firstName || !lastName || !email) {
+      return NextResponse.json(
+        { error: "Prénom, nom et email sont requis." },
+        { status: 400 }
+      );
+    }
+
+    if (!isValidEmail(email)) {
+      return NextResponse.json(
+        { error: "L’adresse email n’est pas valide." },
+        { status: 400 }
+      );
+    }
+
+    const rights = resolveRights(body.requestTypes);
+    if (!rights) {
+      return NextResponse.json(
+        { error: "Sélectionnez au moins un droit à exercer." },
+        { status: 400 }
+      );
+    }
+
+    const resend = new Resend(requireEnv("RESEND_API_KEY"));
+    const from = requireEnv("RESEND_FROM_EMAIL");
+    const to = requireEnv("RGPD_EMAIL_TO");
+
+    const receivedAt = new Date();
+    const rightsList = rights.map((r) => `${r.label} (${r.article})`);
+    const identite = `${firstName} ${lastName}`;
+
+    const internalSubject = sanitizeHeader(
+      `[RGPD] Demande d’exercice de droits — ${identite}`
+    );
+
+    const internalHtml = `
+      <h2>Demande d’exercice de droits RGPD</h2>
+      <p><strong>Demandeur :</strong> ${escapeHtml(firstName)} ${escapeHtml(lastName)}</p>
+      <p><strong>Email :</strong> ${escapeHtml(email)}</p>
+      <p><strong>Téléphone :</strong> ${escapeHtml(phone) || "non renseigné"}</p>
+      <p><strong>Reçue le :</strong> ${receivedAt.toLocaleString("fr-FR")}</p>
+      <hr />
+      <p><strong>Droits invoqués :</strong></p>
+      <ul>
+        ${rightsList.map((r) => `<li>${escapeHtml(r)}</li>`).join("")}
+      </ul>
+      ${details ? `<p><strong>Précisions :</strong><br />${escapeHtmlMultiline(details)}</p>` : ""}
+      <hr />
+      <p><strong>Source :</strong> ${escapeHtml(pageUrl) || "exercer-mes-droits"}</p>
+      <p><em>Délai de réponse légal : ${DELAI_LEGAL} à compter de la réception.
+      Vérifiez l’identité du demandeur avant toute communication de données.</em></p>
+    `;
+
+    const internalText = `
+Demande d’exercice de droits RGPD
+
+Demandeur : ${firstName} ${lastName}
+Email : ${email}
+Téléphone : ${phone || "non renseigné"}
+Reçue le : ${receivedAt.toLocaleString("fr-FR")}
+
+Droits invoqués :
+${rightsList.map((r) => `- ${r}`).join("\n")}
+${details ? `\nPrécisions :\n${details}\n` : ""}
+Source : ${pageUrl || "exercer-mes-droits"}
+
+Délai de réponse légal : ${DELAI_LEGAL} à compter de la réception.
+Vérifiez l’identité du demandeur avant toute communication de données.
+    `.trim();
+
+    const ackSubject = sanitizeHeader(
+      "Votre demande d’exercice de droits — E2I VoIP"
+    );
+
+    const ackHtml = `
+      <h2>Nous avons bien reçu votre demande</h2>
+      <p>Bonjour ${escapeHtml(firstName)},</p>
+      <p>Votre demande d’exercice de droits a été enregistrée le
+      ${escapeHtml(receivedAt.toLocaleDateString("fr-FR"))}. Elle porte sur :</p>
+      <ul>
+        ${rightsList.map((r) => `<li>${escapeHtml(r)}</li>`).join("")}
+      </ul>
+      <p>Conformément au RGPD, une réponse vous sera adressée dans un délai
+      d’${DELAI_LEGAL} à compter de cette date. Nous pouvons être amenés à
+      vous demander un justificatif d’identité avant de vous communiquer des
+      données personnelles.</p>
+      <p>Si vous estimez, après nous avoir contactés, que vos droits ne sont
+      pas respectés, vous pouvez saisir la CNIL (www.cnil.fr).</p>
+      <p>E2I ASSISTANCE</p>
+    `;
+
+    const ackText = `
+Nous avons bien reçu votre demande
+
+Bonjour ${firstName},
+
+Votre demande d’exercice de droits a été enregistrée le ${receivedAt.toLocaleDateString("fr-FR")}. Elle porte sur :
+${rightsList.map((r) => `- ${r}`).join("\n")}
+
+Conformément au RGPD, une réponse vous sera adressée dans un délai d’${DELAI_LEGAL} à compter de cette date. Nous pouvons être amenés à vous demander un justificatif d’identité avant de vous communiquer des données personnelles.
+
+Si vous estimez, après nous avoir contactés, que vos droits ne sont pas respectés, vous pouvez saisir la CNIL (www.cnil.fr).
+
+E2I ASSISTANCE
+    `.trim();
+
+    const [internalResult, ackResult] = await Promise.allSettled([
+      resend.emails.send({
+        from,
+        to,
+        replyTo: email,
+        subject: internalSubject,
+        html: internalHtml,
+        text: internalText,
+      }),
+      resend.emails.send({
+        from,
+        to: email,
+        subject: ackSubject,
+        html: ackHtml,
+        text: ackText,
+      }),
+    ]);
+
+    if (internalResult.status === "rejected") {
+      console.error("[rgpd/demande] Resend (interne) failed:", internalResult.reason);
+      return NextResponse.json(
+        { error: "L’envoi de votre demande a échoué. Veuillez réessayer." },
+        { status: 500 }
+      );
+    }
+
+    if (ackResult.status === "rejected") {
+      // La demande est bien arrivée : on confirme au visiteur, mais l'absence
+      // d'accusé de réception doit rester visible en logs.
+      console.error("[rgpd/demande] Resend (accusé) failed:", ackResult.reason);
+    }
+
+    return NextResponse.json({ ok: true });
+  } catch (e: unknown) {
+    console.error("[rgpd/demande]", e instanceof Error ? e.message : e);
+    return NextResponse.json(
+      { error: "Une erreur est survenue. Veuillez réessayer." },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/studio/devis/route.ts
+++ b/app/api/studio/devis/route.ts
@@ -1,6 +1,13 @@
 import { NextResponse } from "next/server";
 import { Resend } from "resend";
 import { checkRateLimit, getClientIdentifier } from "@/lib/api/rate-limit";
+import {
+  sanitize,
+  escapeHtml,
+  escapeHtmlMultiline,
+  isValidEmail,
+  sanitizeHeader,
+} from "@/lib/api/email-safety";
 import { StudioDemoCategory, getDemoById } from "@/lib/studio-demos";
 
 const HS_BASE = "https://api.hubapi.com";
@@ -36,31 +43,6 @@ const FIELD_LIMITS = {
   notes: 2000,
   pageUrl: 500,
 } as const;
-
-/** Normalise une valeur non fiable en chaîne bornée. */
-function sanitize(value: unknown, max: number): string {
-  if (typeof value !== "string") return "";
-  return value.trim().slice(0, max);
-}
-
-/**
- * Échappe les métacaractères HTML avant interpolation dans l'email.
- * Sans cela, un champ du formulaire peut injecter un lien de phishing dans
- * un message envoyé depuis notre domaine authentifié SPF/DKIM.
- */
-function escapeHtml(value: string): string {
-  return value
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#39;");
-}
-
-/** Échappe puis convertit les retours ligne : l'ordre est important. */
-function escapeHtmlMultiline(value: string): string {
-  return escapeHtml(value).replace(/\n/g, "<br />");
-}
 
 function normalizePhone(phone?: string): string {
   if (!phone) return "";
@@ -154,15 +136,6 @@ async function createNoteForContact(
  * ce qu'on attend d'une adresse professionnelle, ce qui exclut d'office les
  * métacaractères utilisables pour forger un en-tête (`<`, `>`, `"`, `,`, `:`).
  */
-function isValidEmail(email: string): boolean {
-  return /^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$/.test(email);
-}
-
-/** Un en-tête d'email tient sur une ligne : tout CR/LF est retiré. */
-function sanitizeHeader(value: string): string {
-  return value.replace(/[\r\n]+/g, " ").trim();
-}
-
 export interface StudioDevisPayload {
   firstName: string;
   lastName: string;

--- a/app/exercer-mes-droits/page.tsx
+++ b/app/exercer-mes-droits/page.tsx
@@ -1,0 +1,135 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { RgpdRequestForm } from "@/components/forms/rgpd-request-form";
+import { RGPD_RIGHTS } from "@/lib/rgpd/rights";
+
+export const metadata: Metadata = {
+  title: "Exercer mes droits RGPD | E2I VoIP",
+  description:
+    "Formulaire d’exercice des droits RGPD d’E2I ASSISTANCE : accès, rectification, effacement, limitation, portabilité, opposition. Réponse sous un mois.",
+  keywords:
+    "exercer mes droits, RGPD, droit d’accès, droit à l’effacement, portabilité, E2I VoIP",
+  alternates: { canonical: "https://www.e2i-voip.com/exercer-mes-droits" },
+  openGraph: {
+    title: "Exercer mes droits RGPD | E2I VoIP",
+    description:
+      "Déposez votre demande d’exercice de droits auprès d’E2I ASSISTANCE. Réponse dans un délai d’un mois.",
+    type: "website",
+  },
+};
+
+export default function ExercerMesDroitsPage() {
+  return (
+    <>
+      <section className="py-20 bg-gradient-to-r from-blue-900/85 via-blue-800/80 to-red-600/85">
+        <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+          <div className="text-center">
+            <h1 className="mb-6 text-4xl font-bold text-white drop-shadow-lg md:text-6xl">
+              Exercer mes droits
+            </h1>
+            <p className="mx-auto max-w-3xl text-xl leading-relaxed text-white/90">
+              Vous disposez de droits sur les données personnelles qu&rsquo;E2I
+              ASSISTANCE détient à votre sujet. Ce formulaire les déclenche
+              directement, sans passer par un service commercial.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section className="bg-white py-16">
+        <div className="mx-auto max-w-4xl px-4 sm:px-6 lg:px-8">
+          <h2 className="mb-6 text-3xl font-black tracking-[-0.04em] text-gray-dark md:text-4xl">
+            Comment <span className="text-red-primary">ça se passe</span>
+          </h2>
+
+          <ol className="mb-12 space-y-4 text-gray-600">
+            <li className="flex gap-4">
+              <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-red-primary font-bold text-white">
+                1
+              </span>
+              <span>
+                Vous déposez votre demande via le formulaire ci-dessous. Un
+                accusé de réception vous est envoyé immédiatement par email.
+              </span>
+            </li>
+            <li className="flex gap-4">
+              <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-red-primary font-bold text-white">
+                2
+              </span>
+              <span>
+                Nous vérifions votre identité de façon proportionnée à la
+                demande. Un justificatif peut vous être demandé avant toute
+                communication de données personnelles.
+              </span>
+            </li>
+            <li className="flex gap-4">
+              <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-red-primary font-bold text-white">
+                3
+              </span>
+              <span>
+                Vous recevez notre réponse dans un délai d&rsquo;un mois à
+                compter de la réception. Ce délai peut être prolongé de deux
+                mois pour une demande complexe : nous vous en informons alors
+                dans le premier mois.
+              </span>
+            </li>
+          </ol>
+
+          <h2 className="mb-6 text-3xl font-black tracking-[-0.04em] text-gray-dark md:text-4xl">
+            Vos <span className="text-red-primary">droits</span>
+          </h2>
+
+          <dl className="mb-12 space-y-4">
+            {RGPD_RIGHTS.map((right) => (
+              <div
+                key={right.id}
+                className="rounded-lg border border-gray-100 bg-gray-50 p-4"
+              >
+                <dt className="font-semibold text-gray-dark">
+                  {right.label}{" "}
+                  <span className="font-normal text-gray-secondary">
+                    ({right.article} du RGPD)
+                  </span>
+                </dt>
+                <dd className="mt-1 text-gray-600">{right.description}</dd>
+              </div>
+            ))}
+          </dl>
+
+          <RgpdRequestForm />
+
+          <div className="mt-12 rounded-lg border border-gray-100 bg-gray-50 p-6">
+            <h2 className="mb-3 text-xl font-bold text-gray-dark">
+              Si notre réponse ne vous satisfait pas
+            </h2>
+            <p className="text-gray-600">
+              Vous pouvez introduire une réclamation auprès de la Commission
+              nationale de l&rsquo;informatique et des libertés (CNIL), 3 place
+              de Fontenoy, TSA 80715, 75334 Paris Cedex 07, ou en ligne sur{" "}
+              <a
+                href="https://www.cnil.fr/fr/plaintes"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-red-primary underline"
+              >
+                cnil.fr
+              </a>
+              .
+            </p>
+            <p className="mt-4 text-gray-600">
+              Pour comprendre quelles données nous traitons et pourquoi,
+              consultez notre{" "}
+              <Link
+                href="/politique-confidentialite"
+                className="text-red-primary underline"
+              >
+                politique de confidentialité
+              </Link>
+              .
+            </p>
+          </div>
+        </div>
+      </section>
+    </>
+  );
+}

--- a/app/mentions-legales/page.tsx
+++ b/app/mentions-legales/page.tsx
@@ -1,15 +1,21 @@
-import { Metadata } from "next";
+import type { Metadata } from "next";
+import Link from "next/link";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { Shield, TextT, MapPin, Globe, Question, Phone } from '@/lib/icons';
+import { Shield, TextT, MapPin, Globe, Question, Phone } from "@/lib/icons";
+import { COMPANY, HOSTING, LEGAL_LAST_UPDATE } from "@/lib/legal/company";
 
 export const metadata: Metadata = {
   title: "Mentions légales - E2I VoIP",
-  description: "Mentions légales et informations juridiques d'E2I Assistance (E2I VOIP). Découvrez nos informations légales, politique de confidentialité et droits d'auteur.",
-  keywords: "mentions légales, E2I VoIP, politique confidentialité, droits auteur, RGPD, cookies",
+  description:
+    "Mentions légales d’E2I ASSISTANCE (E2I VoIP) : éditeur du site, directeur de la publication, hébergeur, propriété intellectuelle et droit applicable.",
+  keywords:
+    "mentions légales, E2I VoIP, E2I ASSISTANCE, éditeur, hébergeur, propriété intellectuelle",
+  alternates: { canonical: "https://www.e2i-voip.com/mentions-legales" },
   openGraph: {
     title: "Mentions légales - E2I VoIP",
-    description: "Mentions légales et informations juridiques d'E2I Assistance (E2I VOIP).",
+    description:
+      "Mentions légales et informations juridiques d’E2I ASSISTANCE (E2I VoIP).",
     type: "website",
   },
 };
@@ -25,10 +31,9 @@ export default function MentionsLegales() {
   return (
     <>
       {/* Hero Section */}
-      <section className="relative py-20 bg-gradient-to-r from-red-primary to-blue-marine overflow-hidden">
+      <section className="relative py-20 bg-gradient-to-r from-blue-900/85 via-blue-800/80 to-red-600/85 overflow-hidden">
         <div className="absolute inset-0">
-          <div className="absolute inset-0 bg-gradient-to-r from-red-primary/90 to-blue-marine/90 z-10"></div>
-          <div 
+          <div
             className="absolute inset-0 bg-cover bg-center bg-no-repeat opacity-20"
             style={{
               backgroundImage: `url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%23ffffff' fill-opacity='0.1'%3E%3Ccircle cx='30' cy='30' r='2'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E")`,
@@ -39,16 +44,18 @@ export default function MentionsLegales() {
         <div className="relative z-20 max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center">
             <h1 className="text-4xl md:text-6xl font-bold text-white mb-6 drop-shadow-lg">
-              Mentions <span className="text-white">légales</span>
+              Mentions légales
             </h1>
             <p className="text-xl text-white/90 max-w-3xl mx-auto leading-relaxed">
-              Informations juridiques et légales d'E2I Assistance (E2I VOIP)
+              Informations juridiques relatives au site {COMPANY.siteUrl},
+              publiées en application de la loi pour la confiance dans
+              l&rsquo;économie numérique.
             </p>
           </div>
         </div>
       </section>
 
-      {/* Section Éditeur */}
+      {/* Éditeur et hébergement */}
       <section className="py-16 bg-white">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="grid lg:grid-cols-2 gap-12 items-start">
@@ -56,47 +63,91 @@ export default function MentionsLegales() {
               <h2 className="text-3xl md:text-4xl font-black tracking-[-0.04em] text-gray-dark mb-6">
                 <span className="text-red-600">Éditeur</span> du site
               </h2>
-              <div className="space-y-6">
-                <Card className="shadow-lg">
-                  <CardHeader className="bg-gradient-to-r from-red-primary to-blue-marine text-white rounded-t-lg">
-                    <CardTitle className="text-xl font-bold">
-                      E2I ASSISTANCE
-                    </CardTitle>
-                  </CardHeader>
-                  <CardContent className="p-6">
-                    <div className="space-y-4">
-                      <div className="flex items-start space-x-3">
-                        <Shield size={24} className="text-red-600 mt-1 flex-shrink-0" aria-hidden="true" />
-                        <div>
-                          <h3 className="font-semibold text-gray-900">Propriétaire du site</h3>
-                          <p className="text-gray-600">Alban RENIER / E2I ASSISTANCE</p>
-                        </div>
-                      </div>
-                      <div className="flex items-start space-x-3">
-                        <TextT size={24} className="text-red-600 mt-1 flex-shrink-0" aria-hidden="true" />
-                        <div>
-                          <h3 className="font-semibold text-gray-900">SIRET</h3>
-                          <p className="text-gray-600">51743457700014</p>
-                        </div>
-                      </div>
-                      <div className="flex items-start space-x-3">
-                        <TextT size={24} className="text-red-600 mt-1 flex-shrink-0" aria-hidden="true" />
-                        <div>
-                          <h3 className="font-semibold text-gray-900">Code APE</h3>
-                          <p className="text-gray-600">6203Z</p>
-                        </div>
-                      </div>
-                      <div className="flex items-start space-x-3">
-                        <MapPin size={24} className="text-red-600 mt-1 flex-shrink-0" aria-hidden="true" />
-                        <div>
-                          <h3 className="font-semibold text-gray-900">Siège social</h3>
-                          <p className="text-gray-600">23 Chemin Troubiran<br />97300 CAYENNE</p>
-                        </div>
+              <Card className="shadow-lg">
+                <CardHeader className="bg-gradient-to-r from-blue-900/85 via-blue-800/80 to-red-600/85 text-white rounded-t-lg">
+                  <CardTitle className="text-xl font-bold">
+                    {COMPANY.legalName}
+                  </CardTitle>
+                </CardHeader>
+                <CardContent className="p-6">
+                  <div className="space-y-4">
+                    <div className="flex items-start space-x-3">
+                      <Shield
+                        size={24}
+                        className="text-red-600 mt-1 flex-shrink-0"
+                        aria-hidden="true"
+                      />
+                      <div>
+                        <h3 className="font-semibold text-gray-900">
+                          Directeur de la publication
+                        </h3>
+                        <p className="text-gray-600">
+                          {COMPANY.publicationDirector}
+                        </p>
                       </div>
                     </div>
-                  </CardContent>
-                </Card>
-              </div>
+                    <div className="flex items-start space-x-3">
+                      <TextT
+                        size={24}
+                        className="text-red-600 mt-1 flex-shrink-0"
+                        aria-hidden="true"
+                      />
+                      <div>
+                        <h3 className="font-semibold text-gray-900">
+                          Immatriculation
+                        </h3>
+                        <p className="text-gray-600">
+                          SIRET {COMPANY.siret}
+                          <br />
+                          RCS {COMPANY.rcs}
+                          <br />
+                          Code APE {COMPANY.ape} — {COMPANY.apeLabel}
+                        </p>
+                      </div>
+                    </div>
+                    <div className="flex items-start space-x-3">
+                      <MapPin
+                        size={24}
+                        className="text-red-600 mt-1 flex-shrink-0"
+                        aria-hidden="true"
+                      />
+                      <div>
+                        <h3 className="font-semibold text-gray-900">
+                          Siège social
+                        </h3>
+                        <p className="text-gray-600">
+                          {COMPANY.address.street}
+                          <br />
+                          {COMPANY.address.postalCode} {COMPANY.address.city}
+                          <br />
+                          {COMPANY.address.country}
+                        </p>
+                      </div>
+                    </div>
+                    <div className="flex items-start space-x-3">
+                      <Phone
+                        size={24}
+                        className="text-red-600 mt-1 flex-shrink-0"
+                        aria-hidden="true"
+                      />
+                      <div>
+                        <h3 className="font-semibold text-gray-900">Contact</h3>
+                        <p className="text-gray-600">
+                          Par téléphone dans votre région (voir ci-dessous) ou
+                          via notre{" "}
+                          <Link
+                            href="/contact"
+                            className="text-red-600 underline"
+                          >
+                            formulaire de contact
+                          </Link>
+                          .
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                </CardContent>
+              </Card>
             </div>
 
             <div>
@@ -107,11 +158,21 @@ export default function MentionsLegales() {
                 <Card className="shadow-lg">
                   <CardContent className="p-6">
                     <div className="flex items-start space-x-3">
-                      <Globe size={32} className="text-blue-600 mt-1 flex-shrink-0" aria-hidden="true" />
+                      <Globe
+                        size={32}
+                        className="text-blue-600 mt-1 flex-shrink-0"
+                        aria-hidden="true"
+                      />
                       <div>
-                        <h3 className="text-lg font-semibold text-gray-900 mb-2">Plateforme Vercel</h3>
+                        <h3 className="text-lg font-semibold text-gray-900 mb-2">
+                          Hébergeur du site
+                        </h3>
                         <p className="text-gray-600">
-                          Le site internet www.e2i-voip.com est hébergé par la plateforme Vercel.
+                          {HOSTING.provider}
+                          <br />
+                          {HOSTING.address}
+                          <br />
+                          {HOSTING.site}
                         </p>
                       </div>
                     </div>
@@ -120,11 +181,19 @@ export default function MentionsLegales() {
                 <Card className="shadow-lg">
                   <CardContent className="p-6">
                     <div className="flex items-start space-x-3">
-                      <Globe size={32} className="text-green-600 mt-1 flex-shrink-0" aria-hidden="true" />
+                      <Globe
+                        size={32}
+                        className="text-green-600 mt-1 flex-shrink-0"
+                        aria-hidden="true"
+                      />
                       <div>
-                        <h3 className="text-lg font-semibold text-gray-900 mb-2">Gestion du domaine</h3>
+                        <h3 className="text-lg font-semibold text-gray-900 mb-2">
+                          Gestion du nom de domaine
+                        </h3>
                         <p className="text-gray-600">
-                          Le domaine www.e2i-voip.com est enregistré et géré par Hostinger.
+                          {HOSTING.registrar}
+                          <br />
+                          {HOSTING.registrarAddress}
                         </p>
                       </div>
                     </div>
@@ -136,58 +205,78 @@ export default function MentionsLegales() {
         </div>
       </section>
 
-      {/* Section Cookies */}
+      {/* Données personnelles — renvoi vers la politique */}
       <section className="py-16 bg-gray-50">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-12">
             <h2 className="text-3xl md:text-4xl font-black tracking-[-0.04em] text-gray-dark mb-4">
-              Gestion des <span className="text-red-600">cookies</span>
+              Données personnelles et{" "}
+              <span className="text-red-600">cookies</span>
             </h2>
             <p className="text-xl text-gray-600 max-w-3xl mx-auto">
-              Notre politique de gestion des cookies et protection des données
+              Le détail figure dans notre politique de confidentialité, qui
+              fait foi
             </p>
           </div>
 
           <div className="grid lg:grid-cols-2 gap-8">
             <Card className="shadow-lg">
-              <CardHeader className="bg-gradient-to-r from-red-primary to-blue-marine text-white rounded-t-lg">
+              <CardHeader className="bg-gradient-to-r from-blue-900/85 via-blue-800/80 to-red-600/85 text-white rounded-t-lg">
                 <CardTitle className="text-xl font-bold flex items-center">
                   <Question size={24} className="mr-2" aria-hidden="true" />
-                  Cookies et traces
+                  Cookies et traceurs
                 </CardTitle>
               </CardHeader>
               <CardContent className="p-6">
-                <div className="space-y-4">
-                  <p className="text-gray-600">
-                    Le présent site internet dépose des cookies notamment de mesures d'audience avec votre consentement.
+                <div className="space-y-4 text-gray-600">
+                  <p>
+                    Aucun traceur de mesure d&rsquo;audience n&rsquo;est déposé
+                    avant votre acceptation. Le bandeau affiché à votre première
+                    visite vous permet d&rsquo;accepter ou de refuser ; le
+                    refus est le comportement par défaut tant que vous
+                    n&rsquo;avez pas choisi.
                   </p>
-                  <p className="text-gray-600">
-                    Ce dernier vous est proposé à l'aide d'un gestionnaire de site (bandeau) qui vous permet de refuser, d'accepter ou de choisir les traces que vous autorisez.
-                  </p>
-                  <p className="text-gray-600">
-                    Ces traces ne sont pas conservées plus de 13 mois.
+                  <p>
+                    Vous pouvez revenir sur votre choix à tout moment via le
+                    lien <strong>« Gérer mes cookies »</strong> en pied de page.
+                    La liste des traceurs figure dans la{" "}
+                    <Link
+                      href="/politique-confidentialite"
+                      className="text-red-600 underline"
+                    >
+                      politique de confidentialité
+                    </Link>
+                    .
                   </p>
                 </div>
               </CardContent>
             </Card>
 
             <Card className="shadow-lg">
-              <CardHeader className="bg-gradient-to-r from-red-primary to-blue-marine text-white rounded-t-lg">
+              <CardHeader className="bg-gradient-to-r from-blue-900/85 via-blue-800/80 to-red-600/85 text-white rounded-t-lg">
                 <CardTitle className="text-xl font-bold flex items-center">
                   <Shield size={24} className="mr-2" aria-hidden="true" />
-                  Protection des données
+                  Vos droits
                 </CardTitle>
               </CardHeader>
               <CardContent className="p-6">
-                <div className="space-y-4">
-                  <p className="text-gray-600">
-                    Vous pouvez vous adresser à notre société pour exercer vos droits informatiques et libertés via notre <strong>Politique de confidentialité</strong> ou notre formulaire de contact.
+                <div className="space-y-4 text-gray-600">
+                  <p>
+                    {COMPANY.legalName} est responsable du traitement des
+                    données collectées sur ce site. Vous disposez d&rsquo;un
+                    droit d&rsquo;accès, de rectification, d&rsquo;effacement,
+                    de limitation, de portabilité et d&rsquo;opposition.
                   </p>
-                  <p className="text-gray-600">
-                    Notre politique de confidentialité se réfère au Règlement Général sur la Protection des Données (RGPD) qui est entré en vigueur le 25 mai 2018.
-                  </p>
-                  <p className="text-gray-600">
-                    Nous continuerons à vous informer et, le cas échéant, à solliciter votre consentement pour tous nouveaux traitements, dans le respect de cette réglementation.
+                  <p>
+                    Pour les exercer, utilisez notre{" "}
+                    <Link
+                      href="/exercer-mes-droits"
+                      className="text-red-600 underline"
+                    >
+                      formulaire dédié
+                    </Link>
+                    . Une réponse vous est adressée dans un délai d&rsquo;un
+                    mois.
                   </p>
                 </div>
               </CardContent>
@@ -196,39 +285,101 @@ export default function MentionsLegales() {
         </div>
       </section>
 
-      {/* Section Droits d'auteur */}
+      {/* Propriété intellectuelle et responsabilité */}
       <section className="py-16 bg-white">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-12">
             <h2 className="text-3xl md:text-4xl font-black tracking-[-0.04em] text-gray-dark mb-4">
-              <span className="text-red-600">Droits d'auteur</span>
+              <span className="text-red-600">Propriété intellectuelle</span> et
+              responsabilité
             </h2>
-            <p className="text-xl text-gray-600 max-w-3xl mx-auto">
-              Protection de la propriété intellectuelle et droits de reproduction
-            </p>
           </div>
 
-          <Card className="shadow-lg max-w-4xl mx-auto">
-            <CardHeader className="bg-gradient-to-r from-red-primary to-blue-marine text-white rounded-t-lg">
-              <CardTitle className="text-xl font-bold flex items-center">
-                <Question size={24} className="mr-2" aria-hidden="true" />
-                Propriété intellectuelle
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="p-6">
-              <div className="space-y-4">
-                <p className="text-gray-600">
-                  L'ensemble de ce site relève de la législation française et internationale sur les droits d'auteur et la propriété intellectuelle.
-                </p>
-                <p className="text-gray-600">
-                  Tous les droits de reproduction sont réservés, y compris pour les documents téléchargeables et les représentations iconographiques et visuelles.
-                </p>
-                <p className="text-gray-600">
-                  La reproduction de tout ou partie de ce site sur un support quel qu'il soit est formellement interdite sauf autorisation expresse.
-                </p>
-              </div>
-            </CardContent>
-          </Card>
+          <div className="max-w-4xl mx-auto space-y-8">
+            <Card className="shadow-lg">
+              <CardHeader className="bg-gradient-to-r from-blue-900/85 via-blue-800/80 to-red-600/85 text-white rounded-t-lg">
+                <CardTitle className="text-xl font-bold">
+                  Propriété intellectuelle
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="p-6">
+                <div className="space-y-4 text-gray-600">
+                  <p>
+                    L&rsquo;ensemble de ce site relève de la législation
+                    française et internationale sur le droit d&rsquo;auteur et
+                    la propriété intellectuelle. Tous les droits de reproduction
+                    sont réservés, y compris pour les documents téléchargeables
+                    et les représentations iconographiques et visuelles.
+                  </p>
+                  <p>
+                    La reproduction de tout ou partie de ce site sur quelque
+                    support que ce soit est interdite sans autorisation
+                    expresse. Les marques et logos cités, notamment 3CX et
+                    Yeastar, appartiennent à leurs titulaires respectifs.
+                  </p>
+                </div>
+              </CardContent>
+            </Card>
+
+            <Card className="shadow-lg">
+              <CardHeader className="bg-gradient-to-r from-blue-900/85 via-blue-800/80 to-red-600/85 text-white rounded-t-lg">
+                <CardTitle className="text-xl font-bold">
+                  Responsabilité et liens externes
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="p-6">
+                <div className="space-y-4 text-gray-600">
+                  <p>
+                    Les informations publiées sur ce site sont fournies à titre
+                    indicatif. Les descriptions de services, tarifs et
+                    disponibilités ne constituent pas une offre contractuelle :
+                    seul un devis signé engage {COMPANY.legalName}.
+                  </p>
+                  <p>
+                    Ce site peut renvoyer vers des sites tiers dont nous ne
+                    maîtrisons ni le contenu ni les pratiques en matière de
+                    données. Leur consultation relève de votre seule
+                    responsabilité.
+                  </p>
+                </div>
+              </CardContent>
+            </Card>
+
+            <Card className="shadow-lg">
+              <CardHeader className="bg-gradient-to-r from-blue-900/85 via-blue-800/80 to-red-600/85 text-white rounded-t-lg">
+                <CardTitle className="text-xl font-bold">
+                  Droit applicable et litiges
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="p-6">
+                <div className="space-y-4 text-gray-600">
+                  <p>
+                    Les présentes mentions légales sont régies par le droit
+                    français. En cas de litige, une solution amiable sera
+                    recherchée avant toute action contentieuse.
+                  </p>
+                  <p>
+                    Conformément au règlement (UE) n° 524/2013, la Commission
+                    européenne met à disposition une plateforme de règlement en
+                    ligne des litiges, accessible à l&rsquo;adresse{" "}
+                    <a
+                      href="https://ec.europa.eu/consumers/odr"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-red-600 underline"
+                    >
+                      ec.europa.eu/consumers/odr
+                    </a>
+                    .
+                  </p>
+                </div>
+              </CardContent>
+            </Card>
+
+            <p className="text-sm text-gray-secondary text-center">
+              Dernière mise à jour : {LEGAL_LAST_UPDATE}
+            </p>
+          </div>
         </div>
       </section>
 
@@ -240,11 +391,15 @@ export default function MentionsLegales() {
               Nous sommes <span className="text-red-600">certifiés</span> !
             </h2>
             <p className="text-xl text-gray-600 mb-8 max-w-3xl mx-auto">
-              E2I Assistance est partenaire 3CX Silver et certifié ! Visitez le site internet de notre partenaire et souscrivez à une version d'évaluation du standard téléphonique.
+              E2I Assistance est partenaire 3CX Silver et certifié ! Visitez le
+              site internet de notre partenaire et souscrivez à une version
+              d&rsquo;évaluation du standard téléphonique.
             </p>
             <div className="bg-white rounded-lg p-8 shadow-lg inline-block">
               <div className="w-32 h-16 bg-gray-200 rounded flex items-center justify-center">
-                <Badge variant="secondary" className="text-sm">3CX Silver Partner</Badge>
+                <Badge variant="secondary" className="text-sm">
+                  3CX Silver Partner
+                </Badge>
               </div>
             </div>
           </div>
@@ -252,11 +407,11 @@ export default function MentionsLegales() {
       </section>
 
       {/* Section Contact par région */}
-      <section className="py-16 bg-gradient-to-r from-red-primary to-blue-marine">
+      <section className="py-16 bg-gradient-to-r from-blue-900/85 via-blue-800/80 to-red-600/85">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-12">
             <h2 className="text-3xl md:text-4xl font-black tracking-[-0.04em] text-white mb-4">
-              Nos <span className="text-white">implantations</span>
+              Nos implantations
             </h2>
             <p className="text-xl text-white/90 max-w-3xl mx-auto">
               Contactez-nous dans votre région
@@ -264,13 +419,18 @@ export default function MentionsLegales() {
           </div>
 
           <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
-            {contactInfo.map((contact, index) => (
-              <Card key={index} className="bg-white/10 backdrop-blur-sm border-white/20">
+            {contactInfo.map((contact) => (
+              <Card
+                key={contact.region}
+                className="bg-white/10 backdrop-blur-sm border-white/20"
+              >
                 <CardContent className="p-6 text-center">
                   <div className="bg-white/20 w-12 h-12 rounded-lg flex items-center justify-center mx-auto mb-4">
                     <Phone size={24} className="text-white" aria-hidden="true" />
                   </div>
-                  <h3 className="text-lg font-semibold text-white mb-2">{contact.region}</h3>
+                  <h3 className="text-lg font-semibold text-white mb-2">
+                    {contact.region}
+                  </h3>
                   <p className="text-white/90 text-sm">{contact.phone}</p>
                 </CardContent>
               </Card>
@@ -280,4 +440,4 @@ export default function MentionsLegales() {
       </section>
     </>
   );
-} 
+}

--- a/app/politique-confidentialite/page.tsx
+++ b/app/politique-confidentialite/page.tsx
@@ -1,23 +1,65 @@
-import { Metadata } from 'next'
-import { Card, CardContent, CardHeader } from '@/components/ui/card'
-import { Badge } from '@/components/ui/badge'
-import { Shield, Users, Question, Envelope, Lock, Eye, Globe, TextT, DownloadSimple, Timer } from '@/lib/icons';
+import type { Metadata } from "next";
+import Link from "next/link";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Shield, Lock, Globe, Timer } from "@/lib/icons";
+import {
+  COMPANY,
+  HOSTING,
+  LEGAL_LAST_UPDATE,
+  PROCESSINGS,
+  SUB_PROCESSORS,
+  COOKIES,
+} from "@/lib/legal/company";
+import { RGPD_RIGHTS } from "@/lib/rgpd/rights";
 
 export const metadata: Metadata = {
-  title: 'Politique de confidentialité | E2I VoIP',
-  description: 'Notre politique de confidentialité - E2I ASSISTANCE. Découvrez comment nous protégeons vos données personnelles conformément au RGPD.',
-  keywords: 'politique confidentialité, RGPD, protection données, E2I VoIP, cookies, droits utilisateurs',
-  openGraph: {
-    title: 'Politique de confidentialité | E2I VoIP',
-    description: 'Notre politique de confidentialité - E2I ASSISTANCE. Découvrez comment nous protégeons vos données personnelles.',
+  title: "Politique de confidentialité | E2I VoIP",
+  description:
+    "Politique de confidentialité d’E2I ASSISTANCE : traitements mis en œuvre, bases légales, durées de conservation, sous-traitants et exercice de vos droits RGPD.",
+  keywords:
+    "politique de confidentialité, RGPD, protection des données, sous-traitants, cookies, E2I VoIP",
+  alternates: {
+    canonical: "https://www.e2i-voip.com/politique-confidentialite",
   },
+  openGraph: {
+    title: "Politique de confidentialité | E2I VoIP",
+    description:
+      "Comment E2I ASSISTANCE traite et protège vos données personnelles.",
+    type: "website",
+  },
+};
+
+/**
+ * Titre de section homogène sur toute la page.
+ *
+ * Le titre est un `h2` et non un `CardTitle` : ce dernier rend un `h3`, ce
+ * qui casserait la hiérarchie h1 → h2 → h3 dont dépendent les lecteurs
+ * d'écran et l'indexation d'une page aussi longue.
+ */
+function SectionCard({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <Card className="shadow-lg">
+      <CardHeader className="bg-gradient-to-r from-blue-900/85 via-blue-800/80 to-red-600/85 text-white rounded-t-lg">
+        <h2 className="text-xl font-bold leading-none tracking-tight">
+          {title}
+        </h2>
+      </CardHeader>
+      <CardContent className="p-6">{children}</CardContent>
+    </Card>
+  );
 }
 
 export default function PolitiqueConfidentialitePage() {
   return (
     <>
       {/* Hero Section */}
-      <section className="py-16 bg-gradient-to-r from-red-primary to-blue-marine relative overflow-hidden">
+      <section className="py-16 bg-gradient-to-r from-blue-900/85 via-blue-800/80 to-red-600/85 relative overflow-hidden">
         <div className="absolute inset-0 opacity-10">
           <div
             className="absolute inset-0"
@@ -26,436 +68,348 @@ export default function PolitiqueConfidentialitePage() {
             }}
           ></div>
         </div>
-        
+
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 relative z-10">
           <div className="text-center">
             <h1 className="text-4xl md:text-6xl font-bold text-white mb-6 drop-shadow-lg">
-              Politique de <span className="text-white">confidentialité</span>
+              Politique de confidentialité
             </h1>
             <p className="text-xl text-white/90 max-w-3xl mx-auto leading-relaxed">
-              Découvrez comment E2I ASSISTANCE protège vos données personnelles conformément au RGPD
+              Quelles données {COMPANY.legalName} collecte, pourquoi, pour
+              combien de temps, et comment reprendre la main dessus.
             </p>
-            <div className="mt-8 flex items-center justify-center gap-6 text-white/80">
-              <div className="flex items-center gap-2">
-                <div className="w-2 h-2 bg-white rounded-full"></div>
-                <span className="text-sm">Conformité RGPD</span>
-              </div>
-              <div className="flex items-center gap-2">
-                <div className="w-2 h-2 bg-white rounded-full"></div>
-                <span className="text-sm">Protection des données</span>
-              </div>
-              <div className="flex items-center gap-2">
-                <div className="w-2 h-2 bg-white rounded-full"></div>
-                <span className="text-sm">Droits utilisateurs</span>
-              </div>
-            </div>
+            <p className="mt-6 text-sm text-white/80">
+              Dernière mise à jour : {LEGAL_LAST_UPDATE}
+            </p>
           </div>
         </div>
       </section>
 
-      {/* Contenu principal */}
       <section className="py-16">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="max-w-4xl mx-auto">
-            
-            {/* Introduction */}
-            <Card className="shadow-lg mb-8">
-              <CardContent className="p-8">
-                <div className="flex items-start space-x-4 mb-6">
-                  <div className="bg-red-100 p-3 rounded-lg">
-                    <Shield size={32} className="text-red-600" aria-hidden="true" />
-                  </div>
-                  <div>
-                    <h2 className="text-2xl font-bold text-gray-900 mb-4">
-                      Protection de vos données personnelles
-                    </h2>
-                    <p className="text-lg text-gray-600 mb-4">
-                      La société E2I ASSISTANCE est responsable du traitement des données que vous confiez à l'occasion de nos relations en ligne à travers ce site internet.
-                    </p>
-                    <p className="text-gray-600">
-                      Conformément au Règlement Général sur la Protection des Données (RGPD) en vigueur en Europe et à la Loi Informatique et Libertés, la société E2I ASSISTANCE vous informe des conditions d'utilisation et de protection de vos données et des moyens vous permettant d'exercer vos droits et recours.
-                    </p>
-                  </div>
-                </div>
-              </CardContent>
-            </Card>
-
+          <div className="max-w-4xl mx-auto space-y-10">
             {/* Responsable du traitement */}
-            <Card className="shadow-lg mb-8">
-              <CardHeader className="bg-gradient-to-r from-red-primary to-blue-marine text-white rounded-t-lg">
-                <h2 className="text-2xl font-bold">
-                  1. Identité du responsable du traitement
-                </h2>
-              </CardHeader>
-              <CardContent className="p-8">
-                <div className="flex items-start space-x-4">
-                  <div className="bg-red-100 p-3 rounded-lg">
-                    <Users size={32} className="text-red-600" aria-hidden="true" />
-                  </div>
-                  <div>
-                    <h3 className="text-xl font-semibold text-gray-900 mb-2">
-                      E2I ASSISTANCE
+            <SectionCard title="1. Qui est responsable de vos données">
+              <div className="space-y-4 text-gray-600">
+                <p>
+                  {COMPANY.legalName} ({COMPANY.brand}), {COMPANY.address.street}
+                  , {COMPANY.address.postalCode} {COMPANY.address.city},{" "}
+                  {COMPANY.address.country}, immatriculée sous le SIRET{" "}
+                  {COMPANY.siret}, est responsable des traitements décrits
+                  ci-dessous.
+                </p>
+                <p>
+                  Nous n&rsquo;avons pas désigné de délégué à la protection des
+                  données : notre activité ne relève d&rsquo;aucun des cas où
+                  cette désignation est obligatoire (article 37 du RGPD). Vos
+                  demandes sont traitées par la direction, via le{" "}
+                  <Link
+                    href="/exercer-mes-droits"
+                    className="text-red-600 underline"
+                  >
+                    formulaire d&rsquo;exercice des droits
+                  </Link>
+                  .
+                </p>
+              </div>
+            </SectionCard>
+
+            {/* Traitements */}
+            <SectionCard title="2. Ce que nous traitons, et sur quelle base">
+              <p className="mb-6 text-gray-600">
+                Chaque traitement répond à une finalité précise. Nous ne
+                collectons jamais de données « au cas où ».
+              </p>
+              <div className="space-y-6">
+                {PROCESSINGS.map((processing) => (
+                  <div
+                    key={processing.purpose}
+                    className="rounded-lg border border-gray-100 bg-gray-50 p-4"
+                  >
+                    <h3 className="mb-3 font-semibold text-gray-900">
+                      {processing.purpose}
                     </h3>
-                    <p className="text-gray-600 mb-4">
-                      Responsable du traitement des données personnelles
+                    <dl className="space-y-2 text-sm text-gray-600">
+                      <div>
+                        <dt className="inline font-medium text-gray-900">
+                          Base légale :{" "}
+                        </dt>
+                        <dd className="inline">{processing.legalBasis}</dd>
+                      </div>
+                      <div>
+                        <dt className="inline font-medium text-gray-900">
+                          Données :{" "}
+                        </dt>
+                        <dd className="inline">{processing.data}</dd>
+                      </div>
+                      <div>
+                        <dt className="inline font-medium text-gray-900">
+                          Conservation :{" "}
+                        </dt>
+                        <dd className="inline">{processing.retention}</dd>
+                      </div>
+                    </dl>
+                  </div>
+                ))}
+              </div>
+              <p className="mt-6 text-gray-600">
+                Aucun de ces traitements ne donne lieu à une décision
+                automatisée produisant des effets juridiques à votre égard, ni
+                à la revente de vos données à des tiers.
+              </p>
+            </SectionCard>
+
+            {/* Cookies */}
+            <SectionCard title="3. Cookies et traceurs">
+              <div className="space-y-4 text-gray-600">
+                <p>
+                  Tant que vous n&rsquo;avez pas accepté, aucun traceur de
+                  mesure d&rsquo;audience n&rsquo;est chargé : le refus est
+                  l&rsquo;état par défaut. Vous pouvez revenir sur votre choix à
+                  tout moment via le lien{" "}
+                  <strong>« Gérer mes cookies »</strong> en pied de page — le
+                  bandeau réapparaît immédiatement.
+                </p>
+              </div>
+
+              <div className="mt-6 overflow-x-auto">
+                <table className="w-full min-w-[640px] border-collapse text-sm">
+                  <thead>
+                    <tr className="border-b border-gray-200 text-left">
+                      <th className="py-2 pr-4 font-semibold text-gray-900">
+                        Traceur
+                      </th>
+                      <th className="py-2 pr-4 font-semibold text-gray-900">
+                        Émetteur
+                      </th>
+                      <th className="py-2 pr-4 font-semibold text-gray-900">
+                        Finalité
+                      </th>
+                      <th className="py-2 pr-4 font-semibold text-gray-900">
+                        Durée
+                      </th>
+                      <th className="py-2 font-semibold text-gray-900">
+                        Consentement
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {COOKIES.map((cookie) => (
+                      <tr
+                        key={cookie.name}
+                        className="border-b border-gray-100 align-top text-gray-600"
+                      >
+                        <td className="py-3 pr-4 font-mono text-xs">
+                          {cookie.name}
+                        </td>
+                        <td className="py-3 pr-4">{cookie.origin}</td>
+                        <td className="py-3 pr-4">{cookie.purpose}</td>
+                        <td className="py-3 pr-4">{cookie.retention}</td>
+                        <td className="py-3">
+                          {cookie.requiresConsent ? "Requis" : "Non requis"}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+
+              <p className="mt-6 text-gray-600">
+                Certaines pages intègrent des contenus tiers (formulaires Tally,
+                vidéos). Ces contenus peuvent déposer leurs propres traceurs
+                lorsque vous interagissez avec eux ; leurs éditeurs en sont
+                responsables.
+              </p>
+            </SectionCard>
+
+            {/* Sous-traitants */}
+            <SectionCard title="4. À qui vos données sont transmises">
+              <p className="mb-6 text-gray-600">
+                Nous ne vendons ni ne louons vos données. Elles sont accessibles
+                à nos équipes internes et aux prestataires techniques
+                ci-dessous, qui agissent sur nos instructions et sont liés par
+                un contrat de sous-traitance au sens de l&rsquo;article 28 du
+                RGPD.
+              </p>
+              <div className="space-y-4">
+                {SUB_PROCESSORS.map((processor) => (
+                  <div
+                    key={processor.name}
+                    className="rounded-lg border border-gray-100 bg-gray-50 p-4"
+                  >
+                    <h3 className="mb-2 font-semibold text-gray-900">
+                      {processor.name}
+                    </h3>
+                    <p className="text-sm text-gray-600">{processor.purpose}</p>
+                    <p className="mt-2 text-sm text-gray-600">
+                      <span className="font-medium text-gray-900">
+                        Données :{" "}
+                      </span>
+                      {processor.data}
                     </p>
-                    <p className="text-gray-600">
-                      Contact : via notre <a href="/contact" className="text-red-600 hover:text-red-700 font-medium">formulaire de contact</a>
+                    <p className="mt-1 text-sm text-gray-600">
+                      <span className="font-medium text-gray-900">
+                        Hébergement :{" "}
+                      </span>
+                      {processor.location}
+                    </p>
+                  </div>
+                ))}
+              </div>
+              <p className="mt-6 text-gray-600">
+                Vos données peuvent enfin être communiquées aux autorités
+                administratives ou judiciaires lorsque la loi nous y oblige.
+              </p>
+            </SectionCard>
+
+            {/* Sécurité */}
+            <SectionCard title="5. Comment vos données sont protégées">
+              <div className="grid gap-6 sm:grid-cols-2">
+                <div className="flex gap-3">
+                  <Lock
+                    size={24}
+                    className="mt-1 flex-shrink-0 text-red-600"
+                    aria-hidden="true"
+                  />
+                  <div>
+                    <h3 className="font-semibold text-gray-900">
+                      Chiffrement en transit
+                    </h3>
+                    <p className="text-sm text-gray-600">
+                      L&rsquo;intégralité du site est servie en HTTPS. Les
+                      échanges avec nos prestataires sont chiffrés.
                     </p>
                   </div>
                 </div>
-              </CardContent>
-            </Card>
+                <div className="flex gap-3">
+                  <Globe
+                    size={24}
+                    className="mt-1 flex-shrink-0 text-red-600"
+                    aria-hidden="true"
+                  />
+                  <div>
+                    <h3 className="font-semibold text-gray-900">Hébergement</h3>
+                    <p className="text-sm text-gray-600">
+                      Le site est hébergé par {HOSTING.provider}. Les données de
+                      relation client sont hébergées dans l&rsquo;Union
+                      européenne (instance HubSpot eu1).
+                    </p>
+                  </div>
+                </div>
+                <div className="flex gap-3">
+                  <Shield
+                    size={24}
+                    className="mt-1 flex-shrink-0 text-red-600"
+                    aria-hidden="true"
+                  />
+                  <div>
+                    <h3 className="font-semibold text-gray-900">
+                      Accès restreint
+                    </h3>
+                    <p className="text-sm text-gray-600">
+                      Les accès aux outils contenant des données personnelles
+                      sont nominatifs et limités aux personnes qui en ont besoin.
+                    </p>
+                  </div>
+                </div>
+                <div className="flex gap-3">
+                  <Timer
+                    size={24}
+                    className="mt-1 flex-shrink-0 text-red-600"
+                    aria-hidden="true"
+                  />
+                  <div>
+                    <h3 className="font-semibold text-gray-900">
+                      Effacement programmé
+                    </h3>
+                    <p className="text-sm text-gray-600">
+                      Les durées annoncées au point 2 sont des maximums : au
+                      terme, les données sont supprimées ou anonymisées.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </SectionCard>
 
-            {/* Collecte des données */}
-            <Card className="shadow-lg mb-8">
-              <CardHeader className="bg-gradient-to-r from-red-primary to-blue-marine text-white rounded-t-lg">
-                <h2 className="text-2xl font-bold capitalize">
-                  2. données recueillies et utilisées
-                </h2>
-              </CardHeader>
-              <CardContent className="p-8">
-                <p className="text-gray-600 mb-6">
-                  Notre société, selon les finalités des besoins, collecte et utilise vos données personnelles. Cela concerne plusieurs traitements.
+            {/* Droits */}
+            <SectionCard title="6. Vos droits">
+              <p className="mb-6 text-gray-600">
+                Le RGPD vous ouvre les droits suivants sur les données vous
+                concernant.
+              </p>
+              <dl className="space-y-3">
+                {RGPD_RIGHTS.map((right) => (
+                  <div key={right.id}>
+                    <dt className="font-semibold text-gray-900">
+                      {right.label}{" "}
+                      <span className="font-normal text-gray-secondary">
+                        ({right.article})
+                      </span>
+                    </dt>
+                    <dd className="text-gray-600">{right.description}</dd>
+                  </div>
+                ))}
+              </dl>
+
+              <div className="mt-6 rounded-lg border border-gray-100 bg-gray-50 p-4 text-gray-600">
+                <p>
+                  Pour exercer l&rsquo;un de ces droits, utilisez notre{" "}
+                  <Link
+                    href="/exercer-mes-droits"
+                    className="text-red-600 underline"
+                  >
+                    formulaire dédié
+                  </Link>
+                  . Un accusé de réception vous est envoyé immédiatement et
+                  notre réponse vous parvient dans un délai d&rsquo;un mois,
+                  prolongeable de deux mois pour une demande complexe. Un
+                  contrôle d&rsquo;identité proportionné à la demande peut être
+                  effectué.
                 </p>
+              </div>
+            </SectionCard>
 
-                <div className="space-y-6">
-                  {/* Cookies */}
-                  <div className="rounded-xl border border-gray-200 bg-white p-6">
-                    <div className="flex items-start space-x-3 mb-3">
-                      <div className="bg-red-100 p-2 rounded-lg">
-                        <Question size={24} className="text-red-600" aria-hidden="true" />
-                      </div>
-                      <div>
-                        <h3 className="text-lg font-semibold text-gray-900 mb-2">
-                          2.1 Cookies et navigation
-                        </h3>
-                        <p className="text-gray-600">
-                          Le site peut collecter, lorsque vous l'y autorisez, des traces de votre navigation, appelées cookies. Ces traces, par défaut, ne sont pas collectées, sauf si vous l'acceptez par l'intermédiaire de notre bandeau concernant les cookies qui apparaît en page d'accueil. Elles sont utilisées par notre service informatique aux fins de statistiques et sont conservées 13 mois.
-                        </p>
-                      </div>
-                    </div>
-                  </div>
-
-                  {/* Contact */}
-                  <div className="rounded-xl border border-gray-200 bg-white p-6">
-                    <div className="flex items-start space-x-3 mb-3">
-                      <div className="bg-blue-100 p-2 rounded-lg">
-                        <Envelope size={24} className="text-blue-600" aria-hidden="true" />
-                      </div>
-                      <div>
-                        <h3 className="text-lg font-semibold text-gray-900 mb-2">
-                          2.2 Gestion des demandes de contact
-                        </h3>
-                        <p className="text-gray-600 mb-2">
-                          Le site peut collecter vos données à travers un formulaire de gestion de demande de contact. La base juridique de ce traitement est l'intérêt légitime de l'association. Les données concernent des données d'identification telles que le nom, prénom, e-mail, téléphone et des données d'information sur votre demande telles que l'objet, le détail de votre message et la date de votre demande.
-                        </p>
-                        <p className="text-sm font-medium text-red-600">
-                          Les données sont conservées 2 ans.
-                        </p>
-                      </div>
-                    </div>
-                  </div>
-
-                  {/* Candidatures */}
-                  <div className="rounded-xl border border-gray-200 bg-white p-6">
-                    <div className="flex items-start space-x-3 mb-3">
-                      <div className="bg-blue-marine/10 p-2 rounded-lg">
-                        <Users size={24} className="text-blue-marine" aria-hidden="true" />
-                      </div>
-                      <div>
-                        <h3 className="text-lg font-semibold text-gray-900 mb-2">
-                          2.3 Gestion des candidatures
-                        </h3>
-                        <p className="text-gray-600 mb-2">
-                          Le site peut collecter vos données à travers une demande de candidature afin de postuler à une offre d'emploi. La base juridique de ce traitement est l'intérêt légitime de la société et des relations pré-contractuelles. Les données concernent des données d'identification telles que le nom, prénom, e-mail téléphone, adresse, et des données d'information professionnelle sur votre candidature.
-                        </p>
-                        <p className="text-sm font-medium text-red-600">
-                          Les données sont conservées 2 ans.
-                        </p>
-                      </div>
-                    </div>
-                  </div>
-
-                  {/* Paiements */}
-                  <div className="rounded-xl border border-gray-200 bg-white p-6">
-                    <div className="flex items-start space-x-3 mb-3">
-                      <div className="bg-blue-marine/10 p-2 rounded-lg">
-                        <Lock size={24} className="text-blue-marine" aria-hidden="true" />
-                      </div>
-                      <div>
-                        <h3 className="text-lg font-semibold text-gray-900 mb-2">
-                          2.4 Gestion des paiements
-                        </h3>
-                        <p className="text-gray-600">
-                          Les données de paiement sont traitées de manière sécurisée par nos prestataires de paiement certifiés, conformément aux standards de sécurité PCI DSS.
-                        </p>
-                      </div>
-                    </div>
-                  </div>
-
-                  {/* Images */}
-                  <div className="rounded-xl border border-gray-200 bg-white p-6">
-                    <div className="flex items-start space-x-3 mb-3">
-                      <div className="bg-red-50 p-2 rounded-lg">
-                        <Eye size={24} className="text-red-primary" aria-hidden="true" />
-                      </div>
-                      <div>
-                        <h3 className="text-lg font-semibold text-gray-900 mb-2">
-                          2.5 Gestion de vos images
-                        </h3>
-                        <p className="text-gray-600">
-                          Le site lorsque vous avez donné votre accord par écrit peut utiliser votre image. La base légale du traitement est votre consentement. La finalité est la diffusion de votre image dans le but de promouvoir les activités de la société. La durée de conservation des données correspond au temps de la durée de notre actualité et ne peut dépasser 10 ans.
-                        </p>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </CardContent>
-            </Card>
-
-            {/* Hébergement et sécurité */}
-            <Card className="shadow-lg mb-8">
-              <CardHeader className="bg-gradient-to-r from-red-primary to-blue-marine text-white rounded-t-lg">
-                <h2 className="text-2xl font-bold">
-                  3. Comment vos données sont-elles protégées ?
-                </h2>
-              </CardHeader>
-              <CardContent className="p-8">
-                <div className="space-y-6">
-                  {/* Hébergement */}
-                  <div className="flex items-start space-x-4">
-                    <div className="bg-blue-100 p-3 rounded-lg">
-                      <Globe size={32} className="text-blue-600" aria-hidden="true" />
-                    </div>
-                    <div>
-                      <h3 className="text-xl font-semibold text-gray-900 mb-3">
-                        3.1 Lieux d'hébergement
-                      </h3>
-                      <p className="text-gray-600">
-                        Vos données sont stockées, en premier lieu, sur notre site, chez le prestataire hébergeur dûment conforme, puis sur nos serveurs en local. Dans le cas de certains traitements, vos données peuvent être stockées auprès de nos prestataires de services cloud comme Microsoft, Google, HubSpot.
-                      </p>
-                    </div>
-                  </div>
-
-                  {/* Protection */}
-                  <div className="flex items-start space-x-4">
-                    <div className="bg-blue-marine/10 p-3 rounded-lg">
-                      <Lock size={32} className="text-blue-marine" aria-hidden="true" />
-                    </div>
-                    <div>
-                      <h3 className="text-xl font-semibold text-gray-900 mb-3">
-                        3.2 Protection des données
-                      </h3>
-                      <p className="text-gray-600">
-                        Afin de préserver la confidentialité et la sécurité de vos données personnelles et notamment de les protéger contre la destruction illicite ou accidentelle, la perte ou l'altération accidentelle ou encore la divulgation ou l'accès non autorisé, notre société a pris les mesures techniques et organisationnelles appropriées, conformément aux dispositions légales applicables, comme, par exemple, le chiffrement des données pendant les transmissions.
-                      </p>
-                    </div>
-                  </div>
-
-                  {/* Contenu embarqué */}
-                  <div className="flex items-start space-x-4">
-                    <div className="bg-red-50 p-3 rounded-lg">
-                      <Eye size={32} className="text-red-primary" aria-hidden="true" />
-                    </div>
-                    <div>
-                      <h3 className="text-xl font-semibold text-gray-900 mb-3">
-                        3.3 Contenu embarqué
-                      </h3>
-                      <p className="text-gray-600 mb-2">
-                        Les articles de ce site peuvent inclure des contenus intégrés (par exemple des vidéos, images, articles...). Le contenu intégré depuis d'autres sites se comporte de la même manière que si le visiteur se rendait sur cet autre site.
-                      </p>
-                      <p className="text-gray-600">
-                        Ces sites web pourraient collecter des données sur vous, utiliser des cookies, embarquer des outils de suivis tiers, suivre vos interactions avec ces contenus embarqués si vous disposez d'un compte connecté sur leur site web.
-                      </p>
-                    </div>
-                  </div>
-                </div>
-              </CardContent>
-            </Card>
-
-            {/* Droits utilisateurs */}
-            <Card className="shadow-lg mb-8">
-              <CardHeader className="bg-gradient-to-r from-red-primary to-blue-marine text-white rounded-t-lg">
-                <h2 className="text-2xl font-bold">
-                  4. Vos droits utilisateurs
-                </h2>
-              </CardHeader>
-              <CardContent className="p-8">
-                <p className="text-gray-600 mb-6">
-                  Vous disposez de droits dit informatique et libertés. Pour les exercer, vous pouvez nous écrire à notre adresse postale ou en nous écrivant par le <a href="/contact" className="text-red-600 hover:text-red-700 font-medium">formulaire de contact</a>.
-                </p>
-
-                <div className="grid md:grid-cols-2 gap-6 mb-8">
-                  {/* Droit d'accès */}
-                  <Card className="hover:shadow-lg transition-shadow">
-                    <CardContent className="p-6">
-                      <div className="flex items-start space-x-3">
-                        <div className="bg-blue-100 p-2 rounded-lg">
-                          <Eye size={24} className="text-blue-600" aria-hidden="true" />
-                        </div>
-                        <div>
-                          <h4 className="text-lg font-semibold text-gray-900 mb-2">
-                            Droit d'accès
-                          </h4>
-                          <p className="text-gray-600 text-sm">
-                            Vous pouvez exercer votre droit d'accès pour connaître les données personnelles vous concernant. Dans ce cas, nous pourrons vous demander une preuve de votre identité pour en vérifier l'exactitude.
-                          </p>
-                        </div>
-                      </div>
-                    </CardContent>
-                  </Card>
-
-                  {/* Droit de rectification */}
-                  <Card className="hover:shadow-lg transition-shadow">
-                    <CardContent className="p-6">
-                      <div className="flex items-start space-x-3">
-                        <div className="bg-blue-marine/10 p-2 rounded-lg">
-                          <TextT size={24} className="text-blue-marine" aria-hidden="true" />
-                        </div>
-                        <div>
-                          <h4 className="text-lg font-semibold text-gray-900 mb-2">
-                            Droit de rectification
-                          </h4>
-                          <p className="text-gray-600 text-sm">
-                            Si les données personnelles détenues par l'association sont inexactes, vous pouvez demander la mise à jour de vos informations.
-                          </p>
-                        </div>
-                      </div>
-                    </CardContent>
-                  </Card>
-
-                  {/* Droit à l'oubli */}
-                  <Card className="hover:shadow-lg transition-shadow">
-                    <CardContent className="p-6">
-                      <div className="flex items-start space-x-3">
-                        <div className="bg-red-100 p-2 rounded-lg">
-                          <Question size={24} className="text-red-600" aria-hidden="true" />
-                        </div>
-                        <div>
-                          <h4 className="text-lg font-semibold text-gray-900 mb-2 capitalize">
-                            droit à l'oubli
-                          </h4>
-                          <p className="text-gray-600 text-sm">
-                            Vous pouvez demander la suppression de vos données à caractère personnel dans les conditions prévues par l'article 17 du RGPD.
-                          </p>
-                        </div>
-                      </div>
-                    </CardContent>
-                  </Card>
-
-                  {/* Droit à la portabilité */}
-                  <Card className="hover:shadow-lg transition-shadow">
-                    <CardContent className="p-6">
-                      <div className="flex items-start space-x-3">
-                        <div className="bg-blue-marine/10 p-2 rounded-lg">
-                          <DownloadSimple size={24} className="text-blue-marine" aria-hidden="true" />
-                        </div>
-                        <div>
-                          <h4 className="text-lg font-semibold text-gray-900 mb-2">
-                            Droit à la portabilité
-                          </h4>
-                          <p className="text-gray-600 text-sm">
-                            Vous pouvez demander à l'association de vous remettre vos données pour les transmettre à un tiers dans les conditions prévues par l'article 20 du RGPD.
-                          </p>
-                        </div>
-                      </div>
-                    </CardContent>
-                  </Card>
-
-                  {/* Droit d'opposition */}
-                  <Card className="hover:shadow-lg transition-shadow">
-                    <CardContent className="p-6">
-                      <div className="flex items-start space-x-3">
-                        <div className="bg-red-50 p-2 rounded-lg">
-                          <Question size={24} className="text-red-primary" aria-hidden="true" />
-                        </div>
-                        <div>
-                          <h4 className="text-lg font-semibold text-gray-900 mb-2">
-                            Droit d'opposition
-                          </h4>
-                          <p className="text-gray-600 text-sm">
-                            Vous pouvez vous opposer à ce que vos données soient traitées conformément aux hypothèses prévues par l'article 21 du RGPD.
-                          </p>
-                        </div>
-                      </div>
-                    </CardContent>
-                  </Card>
-
-                  {/* Limitation du traitement */}
-                  <Card className="hover:shadow-lg transition-shadow">
-                    <CardContent className="p-6">
-                      <div className="flex items-start space-x-3">
-                        <div className="bg-red-50 p-2 rounded-lg">
-                          <Lock size={24} className="text-red-primary" aria-hidden="true" />
-                        </div>
-                        <div>
-                          <h4 className="text-lg font-semibold text-gray-900 mb-2">
-                            Limitation du traitement
-                          </h4>
-                          <p className="text-gray-600 text-sm">
-                            Vous avez le droit de demander à l'association de limiter le traitement de vos données personnelles conformément aux hypothèses prévues par l'article 18 du RGPD.
-                          </p>
-                        </div>
-                      </div>
-                    </CardContent>
-                  </Card>
-                </div>
-
-                {/* Délai de réponse */}
-                <Card className="bg-blue-50 border-blue-200">
-                  <CardContent className="p-6">
-                    <div className="flex items-start space-x-3">
-                      <div className="bg-blue-100 p-2 rounded-lg">
-                        <Timer size={24} className="text-blue-600" aria-hidden="true" />
-                      </div>
-                      <div>
-                        <h4 className="text-lg font-semibold text-gray-900 mb-2">
-                          Délai de réponse
-                        </h4>
-                        <p className="text-gray-600">
-                          Toute demande d'exercice de vos droits fera l'objet d'un contrôle d'identité proportionné à la demande. Une réponse vous sera adressée dans le délai d'un mois suivant la réception de la demande.
-                        </p>
-                      </div>
-                    </div>
-                  </CardContent>
-                </Card>
-
-                {/* Réclamation CNIL */}
-                <div className="mt-6 p-4 bg-gray-50 rounded-lg">
-                  <h4 className="text-lg font-semibold text-gray-900 mb-2">
-                    Réclamation auprès de la CNIL
-                  </h4>
-                  <p className="text-gray-600">
-                    Si vous estimez, après nous avoir contactés, que vos droits « Informatique et Libertés » ne sont pas respectés, vous pouvez adresser une réclamation à la CNIL.
-                  </p>
-                </div>
-              </CardContent>
-            </Card>
-
-            {/* Certification */}
-            <Card className="shadow-lg bg-gradient-to-r from-red-primary to-blue-marine text-white">
-              <CardContent className="p-8 text-center">
-                <h3 className="text-2xl font-bold mb-4">
-                  Nous sommes certifiés !
-                </h3>
-                <p className="text-white/90 mb-6 max-w-2xl mx-auto">
-                  E2I Assistance est partenaire <strong>3CX Silver</strong> et certifié !
-                  Visitez le site internet de notre partenaire et souscrivez à une version d'évaluation du standard téléphonique.
-                </p>
-                <a 
-                  href="https://www.3cx.fr/pabx/download-pabx-ip/?resellerId=208715" 
-                  target="_blank" 
+            {/* Réclamation */}
+            <SectionCard title="7. Réclamation auprès de la CNIL">
+              <p className="text-gray-600">
+                Si vous estimez, après nous avoir contactés, que vos droits ne
+                sont pas respectés, vous pouvez introduire une réclamation
+                auprès de la Commission nationale de l&rsquo;informatique et
+                des libertés — 3 place de Fontenoy, TSA 80715, 75334 Paris Cedex
+                07, ou en ligne sur{" "}
+                <a
+                  href="https://www.cnil.fr/fr/plaintes"
+                  target="_blank"
                   rel="noopener noreferrer"
-                  className="inline-flex items-center px-6 py-3 bg-white text-red-600 hover:bg-gray-100 font-medium rounded-lg transition-colors duration-200 shadow-lg hover:shadow-xl"
+                  className="text-red-600 underline"
                 >
-                  Découvrir 3CX
+                  cnil.fr
                 </a>
-              </CardContent>
-            </Card>
+                .
+              </p>
+            </SectionCard>
+
+            {/* Évolution */}
+            <SectionCard title="8. Évolution de cette politique">
+              <p className="text-gray-600">
+                Cette politique peut être modifiée pour refléter un nouveau
+                traitement ou une évolution réglementaire. La date de dernière
+                mise à jour figure en tête de page. En cas de changement
+                substantiel affectant un traitement fondé sur votre
+                consentement, celui-ci vous sera à nouveau demandé.
+              </p>
+            </SectionCard>
+
+            <p className="text-center text-sm text-gray-secondary">
+              Voir aussi nos{" "}
+              <Link href="/mentions-legales" className="text-red-600 underline">
+                mentions légales
+              </Link>
+              .
+            </p>
           </div>
         </div>
       </section>
     </>
-  )
+  );
 }

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -75,6 +75,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     // Légal
     { path: "/mentions-legales", changeFrequency: "yearly", priority: 0.3 },
     { path: "/politique-confidentialite", changeFrequency: "yearly", priority: 0.3 },
+    { path: "/exercer-mes-droits", changeFrequency: "yearly", priority: 0.3 },
   ];
 
   const staticEntries: MetadataRoute.Sitemap = routes.map(

--- a/components/cookie-consent-banner.tsx
+++ b/components/cookie-consent-banner.tsx
@@ -2,14 +2,26 @@
 
 import { useEffect, useState, useCallback } from "react";
 import Link from "next/link";
-import { getConsent, acceptCookies, declineCookies } from "@/lib/analytics/consent";
+import {
+  getConsent,
+  acceptCookies,
+  declineCookies,
+  CONSENT_CHANGE_EVENT,
+} from "@/lib/analytics/consent";
 
 export function CookieConsentBanner() {
   const [visible, setVisible] = useState(false);
 
   useEffect(() => {
     // Côté client uniquement : on n'affiche que si aucun choix n'a été fait.
-    if (getConsent() === null) setVisible(true);
+    const sync = () => setVisible(getConsent() === null);
+    sync();
+
+    // « Gérer mes cookies » (footer) efface le choix mémorisé et émet cet
+    // événement : sans cette écoute, le bandeau ne reviendrait qu'au prochain
+    // chargement de page et le retrait paraîtrait sans effet.
+    window.addEventListener(CONSENT_CHANGE_EVENT, sync);
+    return () => window.removeEventListener(CONSENT_CHANGE_EVENT, sync);
   }, []);
 
   const handleAccept = useCallback(async () => {

--- a/components/forms/rgpd-request-form.tsx
+++ b/components/forms/rgpd-request-form.tsx
@@ -1,0 +1,261 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { RGPD_RIGHTS } from "@/lib/rgpd/rights";
+
+type Status = "idle" | "sending" | "success" | "error";
+
+/**
+ * Dépôt d'une demande d'exercice de droits RGPD.
+ *
+ * La validation côté client sert le confort de l'utilisateur, pas la
+ * sécurité : la route /api/rgpd/demande revalide tout, seule source de
+ * vérité. On refuse néanmoins un envoi sans droit coché ici, pour éviter
+ * qu'un aller-retour réseau soit nécessaire à dire une évidence.
+ */
+export function RgpdRequestForm() {
+  const [firstName, setFirstName] = useState("");
+  const [lastName, setLastName] = useState("");
+  const [email, setEmail] = useState("");
+  const [phone, setPhone] = useState("");
+  const [selectedRights, setSelectedRights] = useState<string[]>([]);
+  const [details, setDetails] = useState("");
+  const [status, setStatus] = useState<Status>("idle");
+  const [error, setError] = useState("");
+
+  function toggleRight(id: string) {
+    setSelectedRights((current) =>
+      current.includes(id)
+        ? current.filter((value) => value !== id)
+        : [...current, id]
+    );
+  }
+
+  async function handleSubmit(event: React.FormEvent) {
+    event.preventDefault();
+    setError("");
+
+    if (selectedRights.length === 0) {
+      setError("Sélectionnez au moins un droit à exercer.");
+      return;
+    }
+
+    setStatus("sending");
+
+    try {
+      const res = await fetch("/api/rgpd/demande", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          firstName,
+          lastName,
+          email,
+          phone,
+          // L'ordre suit la liste de référence, pas l'ordre des clics :
+          // l'email interne reste lisible quel que soit le parcours.
+          requestTypes: RGPD_RIGHTS.filter((right) =>
+            selectedRights.includes(right.id)
+          ).map((right) => right.id),
+          details,
+          pageUrl: typeof window !== "undefined" ? window.location.href : "",
+        }),
+      });
+
+      if (res.ok) {
+        setStatus("success");
+        return;
+      }
+
+      const data = await res.json().catch(() => ({}));
+      setError(data.error || "Une erreur est survenue. Veuillez réessayer.");
+      setStatus("error");
+    } catch {
+      setError("Une erreur réseau est survenue. Veuillez réessayer.");
+      setStatus("error");
+    }
+  }
+
+  if (status === "success") {
+    return (
+      <div
+        role="status"
+        className="rounded-2xl border border-gray-100 bg-white p-8 shadow-lg"
+      >
+        <h2 className="mb-4 text-2xl font-bold text-gray-dark">
+          Votre demande est enregistrée
+        </h2>
+        <p className="mb-4 text-gray-600">
+          Un accusé de réception vient de vous être envoyé à l&rsquo;adresse{" "}
+          <strong>{email}</strong>. Conservez-le : il atteste de votre
+          démarche.
+        </p>
+        <p className="text-gray-600">
+          Nous vous répondrons dans un délai d&rsquo;un mois à compter de
+          aujourd&rsquo;hui. Un justificatif d&rsquo;identité pourra vous être
+          demandé avant toute communication de données personnelles.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      noValidate
+      className="rounded-2xl border border-gray-100 bg-white p-6 shadow-lg sm:p-8"
+    >
+      <fieldset className="mb-8">
+        <legend className="mb-4 text-lg font-bold text-gray-dark">
+          Vos coordonnées
+        </legend>
+
+        <div className="grid gap-4 sm:grid-cols-2">
+          <div>
+            <label
+              htmlFor="rgpd-firstname"
+              className="mb-1 block text-sm font-medium text-gray-dark"
+            >
+              Prénom <span className="text-red-primary">*</span>
+            </label>
+            <Input
+              id="rgpd-firstname"
+              value={firstName}
+              onChange={(e) => setFirstName(e.target.value)}
+              autoComplete="given-name"
+              required
+            />
+          </div>
+
+          <div>
+            <label
+              htmlFor="rgpd-lastname"
+              className="mb-1 block text-sm font-medium text-gray-dark"
+            >
+              Nom <span className="text-red-primary">*</span>
+            </label>
+            <Input
+              id="rgpd-lastname"
+              value={lastName}
+              onChange={(e) => setLastName(e.target.value)}
+              autoComplete="family-name"
+              required
+            />
+          </div>
+
+          <div>
+            <label
+              htmlFor="rgpd-email"
+              className="mb-1 block text-sm font-medium text-gray-dark"
+            >
+              Adresse email <span className="text-red-primary">*</span>
+            </label>
+            <Input
+              id="rgpd-email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              autoComplete="email"
+              required
+            />
+            <p className="mt-1 text-xs text-gray-secondary">
+              L&rsquo;accusé de réception et notre réponse seront envoyés à
+              cette adresse.
+            </p>
+          </div>
+
+          <div>
+            <label
+              htmlFor="rgpd-phone"
+              className="mb-1 block text-sm font-medium text-gray-dark"
+            >
+              Téléphone <span className="text-gray-secondary">(facultatif)</span>
+            </label>
+            <Input
+              id="rgpd-phone"
+              type="tel"
+              value={phone}
+              onChange={(e) => setPhone(e.target.value)}
+              autoComplete="tel"
+            />
+          </div>
+        </div>
+      </fieldset>
+
+      <fieldset className="mb-8">
+        <legend className="mb-1 text-lg font-bold text-gray-dark">
+          Droits que vous souhaitez exercer{" "}
+          <span className="text-red-primary">*</span>
+        </legend>
+        <p className="mb-4 text-sm text-gray-secondary">
+          Vous pouvez en sélectionner plusieurs.
+        </p>
+
+        <div className="space-y-3">
+          {RGPD_RIGHTS.map((right) => (
+            <div
+              key={right.id}
+              className="flex gap-3 rounded-lg border border-gray-100 p-3 transition-colors hover:border-red-primary/40"
+            >
+              <input
+                type="checkbox"
+                id={`rgpd-right-${right.id}`}
+                checked={selectedRights.includes(right.id)}
+                onChange={() => toggleRight(right.id)}
+                className="mt-1 h-4 w-4 shrink-0 accent-red-primary"
+              />
+              <label
+                htmlFor={`rgpd-right-${right.id}`}
+                className="cursor-pointer"
+              >
+                <span className="block font-semibold text-gray-dark">
+                  {right.label}{" "}
+                  <span className="font-normal text-gray-secondary">
+                    ({right.article})
+                  </span>
+                </span>
+                <span className="block text-sm text-gray-600">
+                  {right.description}
+                </span>
+              </label>
+            </div>
+          ))}
+        </div>
+      </fieldset>
+
+      <div className="mb-8">
+        <label
+          htmlFor="rgpd-details"
+          className="mb-1 block text-sm font-medium text-gray-dark"
+        >
+          Précisions <span className="text-gray-secondary">(facultatif)</span>
+        </label>
+        <Textarea
+          id="rgpd-details"
+          rows={5}
+          value={details}
+          onChange={(e) => setDetails(e.target.value)}
+          placeholder="Décrivez votre demande : traitement concerné, période, adresse email utilisée lors d’un formulaire…"
+        />
+      </div>
+
+      {error && (
+        <p role="alert" className="mb-4 text-sm font-medium text-red-primary">
+          {error}
+        </p>
+      )}
+
+      <Button type="submit" disabled={status === "sending"} className="w-full sm:w-auto">
+        {status === "sending" ? "Envoi en cours…" : "Envoyer ma demande"}
+      </Button>
+
+      <p className="mt-4 text-xs text-gray-secondary">
+        Les données saisies dans ce formulaire ne servent qu&rsquo;au
+        traitement de votre demande. Elles sont conservées trois ans à des fins
+        de preuve, conformément à la recommandation de la CNIL.
+      </p>
+    </form>
+  );
+}

--- a/components/layout/footer.tsx
+++ b/components/layout/footer.tsx
@@ -1,6 +1,7 @@
 "use client";
 import Link from 'next/link'
 import { PhoneLink } from '@/components/ui/phone-link'
+import { resetConsent } from '@/lib/analytics/consent'
 import { TERRITORY_PHONES } from '@/lib/constants/phone-numbers'
 import { LinkedinLogo, Phone, Headphones } from '@/lib/icons'
 
@@ -220,6 +221,26 @@ export function Footer() {
                 >
                   Politique de confidentialité
                 </Link>
+              </li>
+              <li>
+                <Link
+                  href="/exercer-mes-droits"
+                  className="inline-block py-1 hover:text-red-primary transition-colors"
+                >
+                  Exercer mes droits
+                </Link>
+              </li>
+              <li>
+                {/* Le RGPD impose que retirer son consentement soit aussi
+                    simple que le donner : ce bouton oublie le choix mémorisé
+                    et fait réapparaître le bandeau. */}
+                <button
+                  type="button"
+                  onClick={() => resetConsent()}
+                  className="inline-block py-1 text-left hover:text-red-primary transition-colors"
+                >
+                  Gérer mes cookies
+                </button>
               </li>
               <li>
                 <Link

--- a/env.example
+++ b/env.example
@@ -26,6 +26,7 @@ RESEND_FROM_EMAIL=studio@notifications.e2i-voip.com
 STUDIO_EMAIL_TO=commerciaux@e2i-voip.com
 
 # Resend — demandes d’exercice de droits RGPD (/exercer-mes-droits)
-# Boîte dédiée : une demande soumise à un délai légal d’un mois ne doit pas
-# se perdre dans la boîte commerciale.
-RGPD_EMAIL_TO=rgpd@e2i-voip.com
+# Destinataire distinct de STUDIO_EMAIL_TO : une demande d’exercice de droits
+# est soumise à un délai de réponse légal d’un mois et ne doit pas se noyer
+# dans le flux commercial.
+RGPD_EMAIL_TO=hello@e2i-voip.com

--- a/env.example
+++ b/env.example
@@ -23,4 +23,9 @@ NEXT_PUBLIC_TAWK_TO_ENABLED=false
 # Domaine validé côté Resend : notifications.e2i-voip.com
 RESEND_API_KEY=your_resend_api_key
 RESEND_FROM_EMAIL=studio@notifications.e2i-voip.com
-STUDIO_EMAIL_TO=commerciaux@e2-voip.com
+STUDIO_EMAIL_TO=commerciaux@e2i-voip.com
+
+# Resend — demandes d’exercice de droits RGPD (/exercer-mes-droits)
+# Boîte dédiée : une demande soumise à un délai légal d’un mois ne doit pas
+# se perdre dans la boîte commerciale.
+RGPD_EMAIL_TO=rgpd@e2i-voip.com

--- a/lib/analytics/consent.ts
+++ b/lib/analytics/consent.ts
@@ -41,3 +41,26 @@ export function declineCookies(): void {
   notifyConsentChange()
   // PostHog reste en persistence:'memory' (cookieless) — rien à changer.
 }
+
+/**
+ * Oublie le choix mémorisé : le bandeau réapparaît au prochain rendu.
+ *
+ * Le RGPD impose que retirer son consentement soit aussi simple que le
+ * donner. Repasser PostHog en persistance mémoire est indispensable — sans
+ * cela, le retrait n'aurait aucun effet tant que le visiteur n'a pas
+ * explicitement refusé dans le bandeau réaffiché.
+ */
+export async function resetConsent(): Promise<void> {
+  if (typeof window === 'undefined') return
+  window.localStorage.removeItem(CONSENT_KEY)
+  notifyConsentChange()
+  await import('posthog-js')
+    .then(({ default: posthog }) => {
+      if (posthog?.set_config) {
+        posthog.set_config({ persistence: 'memory' })
+      }
+    })
+    .catch(() => {
+      // SDK bloqué : le choix est oublié malgré tout, le bandeau reviendra.
+    })
+}

--- a/lib/api/email-safety.ts
+++ b/lib/api/email-safety.ts
@@ -1,0 +1,40 @@
+/**
+ * Assainissement des données publiques avant expédition d'un email.
+ *
+ * Les routes publiques du site envoient des emails depuis un domaine
+ * authentifié SPF/DKIM : un champ de formulaire non traité permettrait à un
+ * tiers d'insérer un lien de phishing crédible dans un message signé par
+ * nous, ou d'ajouter un destinataire caché via un en-tête forgé. Ces
+ * fonctions sont volontairement regroupées pour que toute nouvelle route
+ * hérite des mêmes garde-fous.
+ */
+
+/** Normalise une valeur non fiable en chaîne bornée. */
+export function sanitize(value: unknown, max: number): string {
+  if (typeof value !== "string") return "";
+  return value.trim().slice(0, max);
+}
+
+/** Échappe les métacaractères HTML avant interpolation dans l'email. */
+export function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+/** Échappe puis convertit les retours ligne : l'ordre est important. */
+export function escapeHtmlMultiline(value: string): string {
+  return escapeHtml(value).replace(/\n/g, "<br />");
+}
+
+export function isValidEmail(email: string): boolean {
+  return /^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$/.test(email);
+}
+
+/** Un en-tête d'email tient sur une ligne : tout CR/LF est retiré. */
+export function sanitizeHeader(value: string): string {
+  return value.replace(/[\r\n]+/g, " ").trim();
+}

--- a/lib/legal/company.ts
+++ b/lib/legal/company.ts
@@ -1,0 +1,186 @@
+/**
+ * Identité légale et sous-traitants — source unique des pages légales.
+ *
+ * Mentions légales, politique de confidentialité et page d'exercice des
+ * droits lisent ces constantes. Objectif : qu'une correction d'adresse ou
+ * l'ajout d'un sous-traitant ne puisse pas être appliqué à une page en
+ * oubliant l'autre, situation qui a produit les incohérences corrigées ici.
+ *
+ * TODO(alban) — informations à obtenir avant publication définitive :
+ *  - forme juridique exacte (SARL, SAS…) et montant du capital social ;
+ *  - numéro de TVA intracommunautaire, ou mention « TVA non applicable »
+ *    (la TVA n'est pas applicable en Guyane, article 294 du CGI) ;
+ *  - confirmation qu'Alban RENIER est bien directeur de la publication.
+ */
+
+export const COMPANY = {
+  legalName: "E2I ASSISTANCE",
+  brand: "E2I VoIP",
+  siret: "51743457700014",
+  siren: "517 434 577",
+  rcs: "Cayenne 517 434 577",
+  ape: "6203Z",
+  apeLabel: "Gestion d’installations informatiques",
+  publicationDirector: "Alban RENIER",
+  address: {
+    street: "23 Chemin Troubiran",
+    postalCode: "97300",
+    city: "Cayenne",
+    country: "Guyane française",
+  },
+  siteUrl: "www.e2i-voip.com",
+} as const;
+
+/** Date affichée en pied des pages légales. */
+export const LEGAL_LAST_UPDATE = "18 août 2026";
+
+export const HOSTING = {
+  provider: "Vercel Inc.",
+  address: "440 N Barranca Ave #4133, Covina, CA 91723, États-Unis",
+  site: "vercel.com",
+  registrar: "Hostinger International Ltd.",
+  registrarAddress:
+    "61 Lordou Vironos Street, 6023 Larnaca, Chypre",
+} as const;
+
+export interface SubProcessor {
+  name: string;
+  purpose: string;
+  data: string;
+  /** Où les données sont hébergées, et sur quelle base en cas de transfert. */
+  location: string;
+}
+
+/**
+ * Sous-traitants effectivement mobilisés par le site, vérifiés dans le code.
+ *
+ * PostHog figure dans les dépendances du projet mais n'est jamais initialisé
+ * (aucun `posthog.init`) : il ne collecte donc rien aujourd'hui et n'a pas sa
+ * place ici. À réintroduire le jour où il sera réellement activé.
+ */
+export const SUB_PROCESSORS: readonly SubProcessor[] = [
+  {
+    name: "Vercel Inc.",
+    purpose:
+      "Hébergement du site et mesure d’audience agrégée (Vercel Web Analytics, sans cookie).",
+    data: "Adresse IP, journaux de connexion, pages consultées.",
+    location:
+      "États-Unis — clauses contractuelles types de la Commission européenne.",
+  },
+  {
+    name: "HubSpot Inc.",
+    purpose:
+      "Gestion de la relation client, formulaires, chat et suivi de navigation après consentement.",
+    data:
+      "Identité, coordonnées, contenu de vos demandes, pages consultées après consentement.",
+    location:
+      "Union européenne (instance eu1) — transferts encadrés par les clauses contractuelles types.",
+  },
+  {
+    name: "Resend (Plus Five Five, Inc.)",
+    purpose:
+      "Acheminement des emails déclenchés par les formulaires du site.",
+    data: "Identité, adresse email, contenu du message transmis.",
+    location:
+      "États-Unis — clauses contractuelles types de la Commission européenne.",
+  },
+  {
+    name: "Tally BV",
+    purpose:
+      "Formulaires de demande de tarifs et de renseignements intégrés à certaines pages.",
+    data: "Identité, coordonnées, réponses saisies dans le formulaire.",
+    location: "Belgique — Union européenne.",
+  },
+] as const;
+
+export interface Processing {
+  purpose: string;
+  legalBasis: string;
+  data: string;
+  retention: string;
+}
+
+/** Traitements mis en œuvre à travers le site. */
+export const PROCESSINGS: readonly Processing[] = [
+  {
+    purpose: "Répondre à une demande de contact ou de devis",
+    legalBasis:
+      "Mesures précontractuelles prises à votre demande (article 6.1.b du RGPD).",
+    data: "Nom, prénom, email, téléphone, entreprise, contenu de la demande.",
+    retention:
+      "3 ans à compter du dernier contact resté sans suite commerciale.",
+  },
+  {
+    purpose: "Gérer la relation contractuelle et la facturation",
+    legalBasis: "Exécution du contrat et obligations légales comptables.",
+    data: "Identité, coordonnées professionnelles, données de facturation.",
+    retention:
+      "Durée du contrat, puis 10 ans au titre des obligations comptables.",
+  },
+  {
+    purpose: "Produire un message vocal via le Studio Voix Humaines",
+    legalBasis:
+      "Mesures précontractuelles prises à votre demande (article 6.1.b du RGPD).",
+    data:
+      "Identité, coordonnées, texte du message, préférences de voix et de musique.",
+    retention: "3 ans à compter de la dernière demande.",
+  },
+  {
+    purpose: "Mesurer l’audience du site",
+    legalBasis:
+      "Votre consentement, recueilli par le bandeau cookies (article 6.1.a du RGPD).",
+    data:
+      "Pages consultées, provenance, données techniques de navigation. Aucune donnée directement identifiante.",
+    retention: "13 mois maximum, conformément à la recommandation de la CNIL.",
+  },
+  {
+    purpose: "Traiter une demande d’exercice de droits RGPD",
+    legalBasis:
+      "Obligation légale de répondre aux demandes (articles 15 à 22 du RGPD).",
+    data:
+      "Identité, coordonnées, objet de la demande et éventuel justificatif d’identité.",
+    retention:
+      "3 ans à des fins de preuve, conformément à la recommandation de la CNIL.",
+  },
+];
+
+export interface CookieEntry {
+  name: string;
+  origin: string;
+  purpose: string;
+  retention: string;
+  /** Un traceur soumis à consentement n'est déposé qu'après acceptation. */
+  requiresConsent: boolean;
+}
+
+/**
+ * Traceurs réellement déposés par le site, vérifiés dans le code.
+ * Le bandeau conditionne le chargement du script HubSpot : sans acceptation,
+ * aucun cookie de suivi n'est écrit.
+ */
+export const COOKIES: readonly CookieEntry[] = [
+  {
+    name: "e2i-cookie-consent",
+    origin: "E2I VoIP (stockage local, pas un cookie)",
+    purpose:
+      "Mémoriser votre choix d’accepter ou de refuser la mesure d’audience.",
+    retention: "Jusqu’à ce que vous l’effaciez via « Gérer mes cookies ».",
+    requiresConsent: false,
+  },
+  {
+    name: "__hstc, hubspotutk, __hssc, __hssrc",
+    origin: "HubSpot",
+    purpose:
+      "Reconnaître votre navigateur d’une visite à l’autre pour la mesure d’audience et le chat.",
+    retention: "6 mois maximum pour le plus long d’entre eux.",
+    requiresConsent: true,
+  },
+  {
+    name: "Vercel Web Analytics",
+    origin: "Vercel",
+    purpose:
+      "Compter les visites de façon agrégée. Ce dispositif ne dépose aucun cookie et ne suit pas les visiteurs entre les sites.",
+    retention: "Sans objet — aucun identifiant déposé sur votre terminal.",
+    requiresConsent: false,
+  },
+];

--- a/lib/rgpd/rights.ts
+++ b/lib/rgpd/rights.ts
@@ -1,0 +1,66 @@
+/**
+ * Les six droits ouverts par le RGPD, source unique du site.
+ *
+ * La page /exercer-mes-droits, la politique de confidentialité et la route
+ * /api/rgpd/demande consomment cette liste. Un identifiant reçu par la route
+ * qui n'y figure pas est rejeté : cela évite qu'une valeur arbitraire se
+ * retrouve relayée dans l'email interne comme si elle était un droit.
+ */
+
+export interface RgpdRight {
+  /** Identifiant transmis par le formulaire. */
+  id: string;
+  label: string;
+  /** Article du RGPD fondant le droit. */
+  article: string;
+  description: string;
+}
+
+export const RGPD_RIGHTS: readonly RgpdRight[] = [
+  {
+    id: "acces",
+    label: "Droit d’accès",
+    article: "article 15",
+    description:
+      "Obtenir la confirmation que des données vous concernant sont traitées et en recevoir une copie.",
+  },
+  {
+    id: "rectification",
+    label: "Droit de rectification",
+    article: "article 16",
+    description:
+      "Faire corriger des données inexactes ou compléter des données incomplètes.",
+  },
+  {
+    id: "effacement",
+    label: "Droit à l’effacement",
+    article: "article 17",
+    description:
+      "Demander la suppression de vos données, sauf obligation légale de conservation de notre part.",
+  },
+  {
+    id: "limitation",
+    label: "Droit à la limitation du traitement",
+    article: "article 18",
+    description:
+      "Geler l’utilisation de vos données pendant la vérification d’une contestation.",
+  },
+  {
+    id: "portabilite",
+    label: "Droit à la portabilité",
+    article: "article 20",
+    description:
+      "Récupérer les données que vous nous avez fournies dans un format lisible par machine.",
+  },
+  {
+    id: "opposition",
+    label: "Droit d’opposition",
+    article: "article 21",
+    description:
+      "Vous opposer à un traitement fondé sur notre intérêt légitime, dont la prospection commerciale.",
+  },
+] as const;
+
+export function getRightById(id: string): RgpdRight | undefined {
+  return RGPD_RIGHTS.find((right) => right.id === id);
+}

--- a/tests/api/rgpd-demande.test.ts
+++ b/tests/api/rgpd-demande.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Tests de la route publique /api/rgpd/demande.
+ *
+ * Cette route matérialise une obligation légale : une demande d'exercice de
+ * droits doit atteindre l'entreprise, et le demandeur doit conserver une
+ * trace écrite de sa démarche (délai de réponse d'un mois). Les deux envois
+ * n'ont pas le même statut — la notification interne est bloquante, l'accusé
+ * de réception est best-effort.
+ *
+ * Comme pour /api/studio/devis, l'environnement global jsdom n'expose ni
+ * `Request` ni `Response` : ce fichier bascule seul en environnement Node.
+ *
+ * @jest-environment node
+ */
+
+const mockSend = jest.fn();
+
+jest.mock("resend", () => ({
+  Resend: jest.fn().mockImplementation(() => ({
+    emails: { send: mockSend },
+  })),
+}));
+
+import { POST } from "@/app/api/rgpd/demande/route";
+import { resetRateLimits } from "@/lib/api/rate-limit";
+
+const VALID_PAYLOAD = {
+  firstName: "Jean",
+  lastName: "Dupont",
+  email: "jean.dupont@example.fr",
+  phone: "+33 1 23 45 67 89",
+  requestTypes: ["acces", "effacement"],
+  details: "Je souhaite connaître les données détenues me concernant.",
+  pageUrl: "https://www.e2i-voip.com/exercer-mes-droits",
+};
+
+function buildRequest(payload: unknown, ip = "1.2.3.4"): Request {
+  return new Request("https://e2i-voip.com/api/rgpd/demande", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-forwarded-for": ip,
+    },
+    body: JSON.stringify(payload),
+  });
+}
+
+/** Email adressé à la boîte RGPD interne. */
+function internalEmail() {
+  return mockSend.mock.calls
+    .map((call) => call[0])
+    .find((mail) => mail.to === "rgpd@e2i-voip.com");
+}
+
+/** Accusé de réception adressé au demandeur. */
+function acknowledgementEmail() {
+  return mockSend.mock.calls
+    .map((call) => call[0])
+    .find((mail) => mail.to === VALID_PAYLOAD.email);
+}
+
+describe("POST /api/rgpd/demande", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    resetRateLimits();
+    mockSend.mockReset();
+    mockSend.mockResolvedValue({ id: "email-1" });
+
+    process.env = {
+      ...originalEnv,
+      RESEND_API_KEY: "test-key",
+      RESEND_FROM_EMAIL: "rgpd@notifications.e2i-voip.com",
+      RGPD_EMAIL_TO: "rgpd@e2i-voip.com",
+    };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("accepte une demande valide et envoie les deux emails", async () => {
+    const res = await POST(buildRequest(VALID_PAYLOAD));
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ ok: true });
+    expect(mockSend).toHaveBeenCalledTimes(2);
+    expect(internalEmail()).toBeDefined();
+    expect(acknowledgementEmail()).toBeDefined();
+  });
+
+  it("adresse la notification interne à la boîte RGPD, pas à la boîte commerciale", async () => {
+    process.env.STUDIO_EMAIL_TO = "commerciaux@e2i-voip.com";
+
+    await POST(buildRequest(VALID_PAYLOAD));
+
+    const destinataires = mockSend.mock.calls.map((call) => call[0].to);
+    expect(destinataires).toContain("rgpd@e2i-voip.com");
+    expect(destinataires).not.toContain("commerciaux@e2i-voip.com");
+  });
+
+  it("rappelle le délai légal d'un mois dans l'accusé de réception", async () => {
+    await POST(buildRequest(VALID_PAYLOAD));
+
+    const ack = acknowledgementEmail();
+    expect(ack.subject).toMatch(/demande/i);
+    expect(ack.text).toMatch(/un mois/i);
+  });
+
+  it("liste les droits demandés en clair dans la notification interne", async () => {
+    await POST(buildRequest(VALID_PAYLOAD));
+
+    const { text } = internalEmail();
+    expect(text).toMatch(/Droit d’accès/);
+    expect(text).toMatch(/Droit à l’effacement/);
+  });
+
+  it("refuse une demande sans identité", async () => {
+    const res = await POST(
+      buildRequest({ ...VALID_PAYLOAD, lastName: "   " })
+    );
+
+    expect(res.status).toBe(400);
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  it("refuse une adresse email malformée", async () => {
+    const res = await POST(
+      buildRequest({ ...VALID_PAYLOAD, email: "jean<script>@example.fr" })
+    );
+
+    expect(res.status).toBe(400);
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  it("refuse une demande ne portant sur aucun droit", async () => {
+    const res = await POST(buildRequest({ ...VALID_PAYLOAD, requestTypes: [] }));
+
+    expect(res.status).toBe(400);
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  it("refuse un droit inconnu plutôt que de le relayer tel quel", async () => {
+    const res = await POST(
+      buildRequest({ ...VALID_PAYLOAD, requestTypes: ["acces", "<script>"] })
+    );
+
+    expect(res.status).toBe(400);
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  it("échappe le HTML injecté dans les champs texte", async () => {
+    await POST(
+      buildRequest({
+        ...VALID_PAYLOAD,
+        firstName: '<img src=x onerror="alert(1)">',
+        details: '<a href="https://phishing.example">Validez ici</a>',
+      })
+    );
+
+    const { html } = internalEmail();
+    expect(html).not.toContain("<img src=x");
+    expect(html).not.toContain('<a href="https://phishing.example"');
+    expect(html).toContain("&lt;img src=x");
+  });
+
+  it("tronque un champ démesuré avant l'envoi", async () => {
+    await POST(buildRequest({ ...VALID_PAYLOAD, details: "a".repeat(20000) }));
+
+    const { text } = internalEmail();
+    expect(text).toContain("a".repeat(2000));
+    expect(text).not.toContain("a".repeat(2001));
+  });
+
+  it("neutralise un retour ligne injecté dans le sujet", async () => {
+    await POST(
+      buildRequest({
+        ...VALID_PAYLOAD,
+        lastName: "Dupont\nBcc: victime@example.com",
+      })
+    );
+
+    expect(internalEmail().subject).not.toMatch(/[\r\n]/);
+  });
+
+  it("bloque au-delà du quota par adresse IP", async () => {
+    for (let i = 0; i < 3; i += 1) {
+      await POST(buildRequest(VALID_PAYLOAD, "9.9.9.9"));
+    }
+
+    const res = await POST(buildRequest(VALID_PAYLOAD, "9.9.9.9"));
+
+    expect(res.status).toBe(429);
+    expect(res.headers.get("Retry-After")).toBeTruthy();
+  });
+
+  it("confirme la demande même si l'accusé de réception échoue", async () => {
+    mockSend.mockImplementation(async (mail: { to: string }) => {
+      if (mail.to === VALID_PAYLOAD.email) throw new Error("boîte pleine");
+      return { id: "email-1" };
+    });
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    const res = await POST(buildRequest(VALID_PAYLOAD));
+
+    expect(res.status).toBe(200);
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+
+  it("signale une erreur si la notification interne échoue", async () => {
+    mockSend.mockRejectedValue(new Error("Resend down"));
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    const res = await POST(buildRequest(VALID_PAYLOAD));
+
+    expect(res.status).toBe(500);
+    errorSpy.mockRestore();
+  });
+});

--- a/tests/components/footer.test.tsx
+++ b/tests/components/footer.test.tsx
@@ -50,3 +50,20 @@ describe('Footer - Phone Links', () => {
     expect(telLinks.length).toBeGreaterThanOrEqual(4)
   })
 })
+
+describe('Footer — accès aux dispositifs RGPD', () => {
+  test('expose un lien vers le formulaire d’exercice des droits', () => {
+    render(<Footer />)
+
+    const lien = screen.getByRole('link', { name: /exercer mes droits/i })
+    expect(lien).toHaveAttribute('href', '/exercer-mes-droits')
+  })
+
+  test('permet de rouvrir le choix cookies : retirer doit être aussi simple qu’accepter', () => {
+    render(<Footer />)
+
+    expect(
+      screen.getByRole('button', { name: /gérer mes cookies/i })
+    ).toBeInTheDocument()
+  })
+})

--- a/tests/components/rgpd-request-form.test.tsx
+++ b/tests/components/rgpd-request-form.test.tsx
@@ -1,0 +1,95 @@
+/**
+ * Formulaire d'exercice des droits RGPD.
+ *
+ * Le point sensible n'est pas l'esthétique mais la fiabilité du dépôt : une
+ * demande soumise doit partir avec les droits réellement cochés, et le
+ * visiteur doit obtenir une confirmation explicite — c'est sa seule preuve
+ * immédiate d'avoir engagé la démarche.
+ */
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { RgpdRequestForm } from "@/components/forms/rgpd-request-form";
+import { RGPD_RIGHTS } from "@/lib/rgpd/rights";
+
+function remplirIdentite() {
+  fireEvent.change(screen.getByLabelText(/prénom/i), {
+    target: { value: "Jean" },
+  });
+  fireEvent.change(screen.getByLabelText(/^nom/i), {
+    target: { value: "Dupont" },
+  });
+  fireEvent.change(screen.getByLabelText(/email/i), {
+    target: { value: "jean.dupont@example.fr" },
+  });
+}
+
+describe("RgpdRequestForm", () => {
+  beforeEach(() => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValue({ ok: true, json: async () => ({ ok: true }) }) as unknown as typeof fetch;
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  it("propose les six droits du RGPD", () => {
+    render(<RgpdRequestForm />);
+
+    for (const right of RGPD_RIGHTS) {
+      expect(screen.getByLabelText(new RegExp(right.label, "i"))).toBeInTheDocument();
+    }
+  });
+
+  it("refuse la soumission si aucun droit n’est coché", async () => {
+    render(<RgpdRequestForm />);
+    remplirIdentite();
+
+    fireEvent.click(screen.getByRole("button", { name: /envoyer/i }));
+
+    expect(await screen.findByText(/au moins un droit/i)).toBeInTheDocument();
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("transmet les droits cochés à la route API", async () => {
+    render(<RgpdRequestForm />);
+    remplirIdentite();
+    fireEvent.click(screen.getByLabelText(/Droit d’accès/i));
+    fireEvent.click(screen.getByLabelText(/Droit à l’effacement/i));
+
+    fireEvent.click(screen.getByRole("button", { name: /envoyer/i }));
+
+    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+    const [url, init] = (global.fetch as jest.Mock).mock.calls[0];
+    expect(url).toBe("/api/rgpd/demande");
+    expect(JSON.parse(init.body)).toMatchObject({
+      firstName: "Jean",
+      lastName: "Dupont",
+      email: "jean.dupont@example.fr",
+      requestTypes: ["acces", "effacement"],
+    });
+  });
+
+  it("confirme le dépôt et rappelle le délai d’un mois", async () => {
+    render(<RgpdRequestForm />);
+    remplirIdentite();
+    fireEvent.click(screen.getByLabelText(/Droit d’accès/i));
+
+    fireEvent.click(screen.getByRole("button", { name: /envoyer/i }));
+
+    expect(await screen.findByText(/un mois/i)).toBeInTheDocument();
+  });
+
+  it("affiche le message d’erreur renvoyé par le serveur", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      json: async () => ({ error: "Trop de demandes. Réessayez dans quelques minutes." }),
+    }) as unknown as typeof fetch;
+
+    render(<RgpdRequestForm />);
+    remplirIdentite();
+    fireEvent.click(screen.getByLabelText(/Droit d’accès/i));
+
+    fireEvent.click(screen.getByRole("button", { name: /envoyer/i }));
+
+    expect(await screen.findByText(/trop de demandes/i)).toBeInTheDocument();
+  });
+});

--- a/tests/consent.test.ts
+++ b/tests/consent.test.ts
@@ -1,4 +1,12 @@
-import { getConsent, hasAcceptedCookies, CONSENT_KEY, acceptCookies, declineCookies } from '@/lib/analytics/consent'
+import {
+  getConsent,
+  hasAcceptedCookies,
+  CONSENT_KEY,
+  CONSENT_CHANGE_EVENT,
+  acceptCookies,
+  declineCookies,
+  resetConsent,
+} from '@/lib/analytics/consent'
 
 const setConfigMock = jest.fn()
 jest.mock('posthog-js', () => ({
@@ -43,5 +51,38 @@ describe('acceptCookies / declineCookies', () => {
     declineCookies()
     expect(localStorage.getItem(CONSENT_KEY)).toBe('declined')
     expect(setConfigMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('resetConsent', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    setConfigMock.mockClear()
+  })
+
+  it('oublie le choix mémorisé pour que le bandeau réapparaisse', async () => {
+    localStorage.setItem(CONSENT_KEY, 'accepted')
+
+    await resetConsent()
+
+    expect(getConsent()).toBeNull()
+  })
+
+  it('repasse PostHog en persistance mémoire : retirer doit valoir refuser', async () => {
+    localStorage.setItem(CONSENT_KEY, 'accepted')
+
+    await resetConsent()
+
+    expect(setConfigMock).toHaveBeenCalledWith({ persistence: 'memory' })
+  })
+
+  it('émet l’événement de changement pour les éléments fixes de la page', async () => {
+    const listener = jest.fn()
+    window.addEventListener(CONSENT_CHANGE_EVENT, listener)
+
+    await resetConsent()
+
+    expect(listener).toHaveBeenCalled()
+    window.removeEventListener(CONSENT_CHANGE_EVENT, listener)
   })
 })

--- a/tests/cookie-consent-banner.test.tsx
+++ b/tests/cookie-consent-banner.test.tsx
@@ -4,6 +4,12 @@ import * as consent from '@/lib/analytics/consent'
 
 jest.mock('@/lib/analytics/consent')
 
+// L'automock vide les constantes : on récupère le nom réel de l'événement
+// pour que le test et le composant parlent bien du même signal.
+const { CONSENT_CHANGE_EVENT } = jest.requireActual<
+  typeof import('@/lib/analytics/consent')
+>('@/lib/analytics/consent')
+
 afterEach(() => jest.restoreAllMocks())
 
 describe('CookieConsentBanner — visibilité', () => {
@@ -43,6 +49,34 @@ describe('CookieConsentBanner — actions', () => {
     expect(consent.declineCookies).toHaveBeenCalledTimes(1)
     await waitFor(() =>
       expect(screen.queryByRole('button', { name: /refuser/i })).not.toBeInTheDocument()
+    )
+  })
+})
+
+describe('CookieConsentBanner — retrait du consentement', () => {
+  it('réapparaît quand le choix mémorisé est oublié', async () => {
+    // Choix déjà fait au montage : le bandeau est masqué.
+    const getConsent = jest.spyOn(consent, 'getConsent').mockReturnValue('accepted')
+    render(<CookieConsentBanner />)
+    expect(screen.queryByRole('button', { name: /accepter/i })).not.toBeInTheDocument()
+
+    // « Gérer mes cookies » efface le choix puis émet l'événement.
+    getConsent.mockReturnValue(null)
+    fireEvent(window, new CustomEvent(CONSENT_CHANGE_EVENT))
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /accepter/i })).toBeInTheDocument()
+    )
+  })
+
+  it('ne se réaffiche pas quand l’événement accompagne un choix ferme', async () => {
+    jest.spyOn(consent, 'getConsent').mockReturnValue('declined')
+    render(<CookieConsentBanner />)
+
+    fireEvent(window, new CustomEvent(CONSENT_CHANGE_EVENT))
+
+    await waitFor(() =>
+      expect(screen.queryByRole('button', { name: /accepter/i })).not.toBeInTheDocument()
     )
   })
 })

--- a/tests/e2e/cookie-consent.spec.ts
+++ b/tests/e2e/cookie-consent.spec.ts
@@ -47,3 +47,42 @@ test.describe('Bandeau de consentement cookies', () => {
     ).toBeHidden()
   })
 })
+
+test.describe('Retrait du consentement', () => {
+  test('« Gérer mes cookies » rouvre le choix après une acceptation', async ({
+    page,
+  }) => {
+    await gotoHome(page)
+    await banner(page).getByRole('button', { name: /accepter/i }).click()
+    await expect(banner(page)).toBeHidden()
+
+    // Le lien vit en pied de page : c'est le seul point de retrait offert au
+    // visiteur, il doit rester atteignable sans passer par une page légale.
+    await page
+      .getByRole('button', { name: /gérer mes cookies/i })
+      .click()
+
+    await expect(banner(page)).toBeVisible()
+
+    // Le retrait doit valoir refus tant qu'aucun nouveau choix n'est fait :
+    // un choix mémorisé qui survivrait rendrait le bouton décoratif.
+    const choice = await page.evaluate(() =>
+      localStorage.getItem('e2i-cookie-consent')
+    )
+    expect(choice).toBeNull()
+  })
+
+  test('un nouveau refus après retrait est bien mémorisé', async ({ page }) => {
+    await gotoHome(page)
+    await banner(page).getByRole('button', { name: /accepter/i }).click()
+    await page.getByRole('button', { name: /gérer mes cookies/i }).click()
+
+    await banner(page).getByRole('button', { name: /refuser/i }).click()
+    await expect(banner(page)).toBeHidden()
+
+    const choice = await page.evaluate(() =>
+      localStorage.getItem('e2i-cookie-consent')
+    )
+    expect(choice).toBe('declined')
+  })
+})

--- a/tests/lib/email-safety.test.ts
+++ b/tests/lib/email-safety.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Helpers partagés par les routes d'email transactionnel.
+ *
+ * Ces fonctions sont la seule barrière entre un corps de requête public et
+ * un email expédié depuis un domaine authentifié SPF/DKIM : elles méritent
+ * une couverture propre, indépendante de la route qui les consomme.
+ */
+import {
+  sanitize,
+  escapeHtml,
+  escapeHtmlMultiline,
+  isValidEmail,
+  sanitizeHeader,
+} from "@/lib/api/email-safety";
+
+describe("sanitize", () => {
+  it("borne la longueur et retire les espaces de bord", () => {
+    expect(sanitize("  Jean  ", 10)).toBe("Jean");
+    expect(sanitize("a".repeat(50), 10)).toBe("a".repeat(10));
+  });
+
+  it("ramène toute valeur non textuelle à une chaîne vide", () => {
+    expect(sanitize(42, 10)).toBe("");
+    expect(sanitize(null, 10)).toBe("");
+    expect(sanitize({ toString: () => "malin" }, 10)).toBe("");
+  });
+});
+
+describe("escapeHtml", () => {
+  it("neutralise les métacaractères HTML", () => {
+    expect(escapeHtml('<img src=x onerror="alert(1)">')).toBe(
+      "&lt;img src=x onerror=&quot;alert(1)&quot;&gt;"
+    );
+  });
+
+  it("échappe l'esperluette avant les autres entités", () => {
+    expect(escapeHtml("&lt;")).toBe("&amp;lt;");
+  });
+});
+
+describe("escapeHtmlMultiline", () => {
+  it("échappe puis convertit les retours ligne", () => {
+    expect(escapeHtmlMultiline("Ligne 1\n<b>Ligne 2</b>")).toBe(
+      "Ligne 1<br />&lt;b&gt;Ligne 2&lt;/b&gt;"
+    );
+  });
+});
+
+describe("isValidEmail", () => {
+  it("accepte une adresse ordinaire", () => {
+    expect(isValidEmail("jean.dupont@example.fr")).toBe(true);
+  });
+
+  it("refuse une adresse porteuse de balises ou d'espaces", () => {
+    expect(isValidEmail("jean<script>@example.fr")).toBe(false);
+    expect(isValidEmail("jean dupont@example.fr")).toBe(false);
+    expect(isValidEmail("jean@example")).toBe(false);
+  });
+});
+
+describe("sanitizeHeader", () => {
+  it("écrase les retours ligne injectés dans un en-tête", () => {
+    expect(sanitizeHeader("Acme\nBcc: victime@example.com")).toBe(
+      "Acme Bcc: victime@example.com"
+    );
+    expect(sanitizeHeader("Acme\r\nBcc: x")).not.toMatch(/[\r\n]/);
+  });
+});

--- a/tests/politique-confidentialite.test.tsx
+++ b/tests/politique-confidentialite.test.tsx
@@ -1,66 +1,78 @@
 import { render, screen } from '@testing-library/react'
 
 import PolitiqueConfidentialitePage from '../app/politique-confidentialite/page'
+import { SUB_PROCESSORS } from '@/lib/legal/company'
+import { RGPD_RIGHTS } from '@/lib/rgpd/rights'
 
 describe('Page Politique de Confidentialité', () => {
   it('affiche le titre principal', () => {
     render(<PolitiqueConfidentialitePage />)
-    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('Politique de confidentialité')
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
+      'Politique de confidentialité'
+    )
   })
 
-  it('affiche le nom de la société', () => {
+  it('identifie le responsable du traitement', () => {
     render(<PolitiqueConfidentialitePage />)
-    const companyNames = screen.getAllByText('E2I ASSISTANCE')
-    expect(companyNames.length).toBeGreaterThan(0)
-    expect(companyNames[0]).toBeInTheDocument()
+    expect(screen.getAllByText(/E2I ASSISTANCE/).length).toBeGreaterThan(0)
+    expect(screen.getByText(/51743457700014/)).toBeInTheDocument()
   })
 
-  it('contient les sections principales', () => {
+  it('contient les sections attendues d’une politique conforme', () => {
     render(<PolitiqueConfidentialitePage />)
-    
-    expect(screen.getByText(/Identité du responsable du traitement/)).toBeInTheDocument()
-    expect(screen.getByText(/données recueillies et utilisées/)).toBeInTheDocument()
-    expect(screen.getByText(/Comment vos données sont-elles protégées/)).toBeInTheDocument()
+
+    expect(screen.getByText(/Qui est responsable de vos données/)).toBeInTheDocument()
+    expect(screen.getByText(/Ce que nous traitons, et sur quelle base/)).toBeInTheDocument()
+    expect(screen.getByText(/Cookies et traceurs/)).toBeInTheDocument()
+    expect(screen.getByText(/À qui vos données sont transmises/)).toBeInTheDocument()
+    expect(screen.getByText(/Comment vos données sont protégées/)).toBeInTheDocument()
     expect(screen.getByText(/Vos droits/)).toBeInTheDocument()
+    expect(screen.getByText(/Réclamation auprès de la CNIL/)).toBeInTheDocument()
   })
 
-  it('contient les droits RGPD', () => {
+  it('énumère les six droits RGPD depuis la source unique', () => {
     render(<PolitiqueConfidentialitePage />)
-    
-    expect(screen.getByText(/Droit d'accès/)).toBeInTheDocument()
-    expect(screen.getByText(/Droit de rectification/)).toBeInTheDocument()
-    expect(screen.getByText(/droit à l'oubli/)).toBeInTheDocument()
-    expect(screen.getByText(/Droit à la portabilité/)).toBeInTheDocument()
+
+    for (const right of RGPD_RIGHTS) {
+      expect(screen.getAllByText(new RegExp(right.label)).length).toBeGreaterThan(0)
+    }
   })
 
-  it('contient les liens vers le formulaire de contact', () => {
+  it('nomme chaque sous-traitant : l’information est due au visiteur', () => {
     render(<PolitiqueConfidentialitePage />)
-    
-    const contactLinks = screen.getAllByRole('link', { name: /formulaire de contact/i })
-    expect(contactLinks.length).toBeGreaterThan(0)
-    contactLinks.forEach(link => {
-      expect(link).toHaveAttribute('href', '/contact')
-    })
+
+    for (const processor of SUB_PROCESSORS) {
+      expect(screen.getByText(processor.name)).toBeInTheDocument()
+    }
   })
 
-  it('contient la certification 3CX', () => {
+  it('précise une base légale et une durée pour chaque traitement', () => {
     render(<PolitiqueConfidentialitePage />)
-    
-    expect(screen.getByText(/3CX Silver/)).toBeInTheDocument()
-    expect(screen.getByRole('link', { name: /Découvrir 3CX/i })).toHaveAttribute('href', 'https://www.3cx.fr/pabx/download-pabx-ip/?resellerId=208715')
+
+    const basesLegales = screen.getAllByText(/Base légale :/)
+    const durees = screen.getAllByText(/Conservation :/)
+    expect(basesLegales.length).toBe(durees.length)
+    expect(basesLegales.length).toBeGreaterThanOrEqual(5)
   })
 
-  it('respecte la structure sémantique', () => {
+  it('renvoie vers le formulaire d’exercice des droits', () => {
     render(<PolitiqueConfidentialitePage />)
-    
-    const headings = screen.getAllByRole('heading')
-    expect(headings.length).toBeGreaterThan(5) // Au moins 6 titres
-    
-    // Vérifier la hiérarchie des titres
-    const h1 = screen.getByRole('heading', { level: 1 })
-    const h2s = screen.getAllByRole('heading', { level: 2 })
-    
-    expect(h1).toBeInTheDocument()
-    expect(h2s.length).toBeGreaterThan(3)
+
+    const liens = screen
+      .getAllByRole('link')
+      .filter((l) => l.getAttribute('href') === '/exercer-mes-droits')
+    expect(liens.length).toBeGreaterThan(0)
+  })
+
+  it('affiche une date de dernière mise à jour', () => {
+    render(<PolitiqueConfidentialitePage />)
+    expect(screen.getByText(/Dernière mise à jour/)).toBeInTheDocument()
+  })
+
+  it('respecte la hiérarchie des titres', () => {
+    render(<PolitiqueConfidentialitePage />)
+
+    expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument()
+    expect(screen.getAllByRole('heading', { level: 2 }).length).toBeGreaterThan(3)
   })
 })


### PR DESCRIPTION
## Contexte

Les deux pages légales existantes décrivaient un traitement de données qui ne correspondait pas à celui réellement mis en œuvre par le site, et aucun dispositif ne permettait à un visiteur d'agir sur ses données.

## Ce que fait cette PR

### Politique de confidentialité — réécriture complète
- Suppression des mentions « **l'association** » (4 occurrences), vestiges d'un copier-coller depuis un autre site.
- Chaque traitement porte désormais sa **finalité, sa base légale, les données concernées et sa durée de conservation**.
- Les **sous-traitants sont nommés** — Vercel, HubSpot, Resend, Tally — avec leur localisation et l'encadrement des transferts. Cette information est due au visiteur et était totalement absente.
- **Tableau des traceurs** réellement déposés, vérifiés dans le code.
- Date de dernière mise à jour.

### Mentions légales
Directeur de la publication, RCS, adresse complète de l'hébergeur (obligation LCEN), responsabilité et liens externes, droit applicable, plateforme européenne de règlement des litiges. La section cookies, qui doublonnait la politique, y renvoie désormais.

### Exercice des droits — nouveau
- Page `/exercer-mes-droits` avec les 6 droits du RGPD et un formulaire.
- Route `/api/rgpd/demande` calquée sur `/api/studio/devis` : rate-limit, plafonds par champ, échappement HTML, protection contre l'injection d'en-tête.
- Notification interne vers **`RGPD_EMAIL_TO`** (boîte dédiée) + **accusé de réception** au demandeur rappelant le délai d'un mois.
- L'accusé est best-effort : son échec ne doit pas laisser croire qu'une demande arrivée est perdue.

### Retrait du consentement
Le bandeau ne pouvait **jamais** être rouvert : un visiteur ayant accepté ne pouvait plus revenir en arrière, alors que le RGPD impose que retirer soit aussi simple qu'accepter. Le lien « Gérer mes cookies » du pied de page efface le choix, repasse PostHog en persistance mémoire et fait réapparaître le bandeau.

### Au passage
- Helpers d'assainissement des emails extraits dans `lib/api/email-safety.ts`, partagés avec `/api/studio/devis`.
- Titres de section de la politique redevenus des `h2` — `CardTitle` rend un `h3`, ce qui cassait la hiérarchie h1 → h2 → h3.
- Heros repassés sur le gradient de charte `from-blue-900/85 via-blue-800/80 to-red-600/85` (règle absolue n°2 ; ils étaient en `from-red-primary to-blue-marine`).
- Typo corrigée : `STUDIO_EMAIL_TO=commerciaux@e2**i**-voip.com` dans `env.example`.

## ⚠️ À faire avant merge

~~**1. Variable d'environnement Vercel**~~ — ✅ Fait. `RGPD_EMAIL_TO=hello@e2i-voip.com` créée sur Production, Preview et Development.

`RESEND_API_KEY`, `RESEND_FROM_EMAIL` et `STUDIO_EMAIL_TO` ont également été étendus à **tous** les previews : ils étaient limités à la Production et à la seule branche `feat/studio-formulaire-devis`, ce qui aurait fait échouer en 500 le formulaire RGPD (et le formulaire studio) sur le preview de cette PR.

⚠️ Reste à vérifier à la main : la valeur de `STUDIO_EMAIL_TO` en Production. Elle est marquée *Sensitive* et illisible via `vercel env pull` — impossible de confirmer si elle porte la typo `e2-voip.com` corrigée ici dans `env.example`.

**2. Informations légales manquantes** — signalées en `TODO(alban)` dans `lib/legal/company.ts` :
- forme juridique exacte et capital social ;
- numéro de TVA intracommunautaire, **ou** mention « TVA non applicable » (la TVA n'est pas applicable en Guyane, art. 294 du CGI — d'où l'absence de valeur devinée ici) ;
- confirmation qu'Alban RENIER est bien directeur de la publication.

**3. Constat technique** — `posthog-js` est dans les dépendances mais **`posthog.init()` n'est appelé nulle part** : PostHog ne collecte donc rien aujourd'hui. Il a été écarté de la liste des sous-traitants pour cette raison. À réintroduire le jour où il sera activé.

## Tests

TDD (RED → GREEN) sur les trois volets :
- `tests/api/rgpd-demande.test.ts` — 13 tests : validation, droits inconnus rejetés, échappement HTML, injection d'en-tête, rate-limit, dégradation de l'accusé de réception.
- `tests/components/rgpd-request-form.test.tsx` — 5 tests.
- `tests/lib/email-safety.test.ts` — 9 tests sur les helpers extraits.
- `tests/consent.test.ts`, `tests/cookie-consent-banner.test.tsx` — retrait du consentement.
- `tests/politique-confidentialite.test.tsx` — réécrit sur le nouveau contenu.

`npm run validate` : lint (0 erreur), type-check, **67 suites Jest / 427 tests au vert**, audit sécurité, build.

Playwright : 96 passés, 9 échecs sur `blog-seo` et `blog-hubspot-images` — **préexistants sur `dev`** (vérifié par checkout), causés par un token HubSpot expiré en local (401), sans rapport avec cette PR.

## Validation sur le preview

Testé sur le déploiement `e2ivoip-3s51hcon1` (redéployé après création des variables) :

| Cas | Attendu | Obtenu |
|---|---|---|
| `GET /exercer-mes-droits` | page servie avec les 6 droits | ✅ 200, rendu serveur complet |
| `POST` demande valide | 200 + 2 emails | ✅ `{"ok":true}` — email reçu sur hello@e2i-voip.com |
| `POST` email malformé | 400 | ✅ « L'adresse email n'est pas valide. » |
| `POST` sans droit sélectionné | 400 | ✅ « Sélectionnez au moins un droit à exercer. » |
| 4ᵉ requête dans la fenêtre | 429 | ✅ quota de 3 / 15 min appliqué |

Le cas « droit inconnu » n'a pas pu être rejoué en direct — le quota était déjà consommé, le rate-limit passant avant la validation. Il reste couvert par `tests/api/rgpd-demande.test.ts`.

Retrait du consentement : 2 tests Playwright ajoutés (`tests/e2e/cookie-consent.spec.ts`) couvrant accepter → retirer → bandeau réaffiché → refuser. 4 tests au vert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

