### PR TITLE
feat(seo): cibler la page d'accueil sur l'opérateur télécom DOM

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,7 +3,7 @@ import { Inter, IBM_Plex_Mono } from "next/font/google";
 import "./globals.css";
 import { LayoutClientChrome } from "@/components/layout/layout-client-chrome";
 import { Footer } from "@/components/layout/footer";
-import { SITE_URL, SITE_NAME } from "@/lib/site";
+import { HOME_PAGE_TITLE, SITE_URL, SITE_NAME } from "@/lib/site";
 import { JsonLd } from "@/components/seo/json-ld";
 import { organizationSchema, websiteSchema } from "@/lib/structured-data";
 import { Analytics } from "@vercel/analytics/next";
@@ -32,7 +32,7 @@ export const metadata: Metadata = {
   // références manuelles. Les anciens fichiers public/favicon-*.png restent
   // disponibles comme fallback pour les anciens navigateurs.
   title: {
-    default: "E2I VoIP - Solutions de téléphonie IP professionnelles",
+    default: HOME_PAGE_TITLE,
     // Les pages enfant qui définissent un title court héritent du suffixe marque.
     template: `%s | ${SITE_NAME}`,
   },
@@ -48,7 +48,7 @@ export const metadata: Metadata = {
     canonical: "/",
   },
   openGraph: {
-    title: "E2I VoIP - Solutions de téléphonie IP professionnelles",
+    title: HOME_PAGE_TITLE,
     description:
       "Solutions de téléphonie IP professionnelles pour optimiser vos communications d'entreprise.",
     type: "website",
@@ -66,7 +66,7 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: "summary_large_image",
-    title: "E2I VoIP - Solutions de téléphonie IP professionnelles",
+    title: HOME_PAGE_TITLE,
     description:
       "Solutions de téléphonie IP professionnelles pour optimiser vos communications d'entreprise.",
     images: ["/images/e2i-voip-partage.png"],

--- a/docs/ADR.md
+++ b/docs/ADR.md
@@ -10,6 +10,13 @@ Ce fichier centralise les décisions importantes prises sur le projet. Chaque en
 
 ## Historique
 
+### 2026-08-21 — Titre SEO de la page d’accueil ciblé sur les DOM
+
+- **Contexte** : le titre de la page d’accueil décrivait des solutions de téléphonie IP professionnelles sans exprimer le positionnement différenciant d’E2I VoIP ni sa zone prioritaire.
+- **Décision** : remplacer le titre HTML par « Opérateur de services télécom DOM | E2I VoIP » et aligner `og:title` ainsi que `twitter:title`. Les titres spécifiques des pages internes et la description SEO restent inchangés.
+- **Conséquences** : l’intention « opérateur télécom DOM » apparaît dès le début du titre, la marque reste identifiable et les aperçus sociaux emploient le même message.
+- **Tests associés** : `tests/playwright/metadata-sociale.spec.ts` vérifie le `<title>`, `og:title` et `twitter:title` rendus sur la page d’accueil.
+
 ### 2026-08-19 — Durcissement anti-spam du formulaire d’exercice des droits RGPD
 
 - **Contexte** : la route publique `/api/rgpd/demande` déclenche des emails depuis un domaine authentifié et matérialise une obligation légale. Elle validait déjà les champs, bornait les longueurs, échappait le HTML, rejetait les droits inconnus et limitait le débit par IP, mais restait exposée aux POST automatisés simples et aux robots capables d’utiliser la route comme relais d’emails.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -17,3 +17,5 @@
 > **Maintenance sécurité (2026-08-14)** : 28 vulnérabilités npm résolues ; Next.js 16.3.1 et Puppeteer 25.7.0 validés. Voir `docs/superpowers/plans/2026-08-14-npm-security-next16.md`.
 >
 > **Maintenance sécurité (2026-08-19)** : formulaire `/exercer-mes-droits` durci contre spam/robots : contrôles Origin/Fetch Metadata, en-tête d’intention, limite de corps, honeypot, délai minimal et Turnstile optionnel. Voir `docs/ADR.md`.
+>
+> **Optimisation SEO (2026-08-21)** : titre de la page d’accueil recentré sur le positionnement « Opérateur de services télécom DOM », avec métadonnées sociales alignées. Voir `docs/ADR.md`.

--- a/docs/superpowers/plans/2026-08-21-titre-seo-operateur-telecom-dom.md
+++ b/docs/superpowers/plans/2026-08-21-titre-seo-operateur-telecom-dom.md
@@ -1,0 +1,271 @@
+# Titre SEO opérateur télécom DOM Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Positionner la page d’accueil sur « opérateur télécom DOM » avec un titre unique et cohérent dans le HTML, Open Graph et Twitter.
+
+**Architecture:** Conserver les métadonnées statiques du layout racine prévues par l’App Router Next.js 16. Centraliser le titre dans `lib/site.ts`, déjà source de vérité SEO, puis le réutiliser pour le titre par défaut et les deux titres sociaux ; un test unitaire couvrira la règle SEO et un test Playwright vérifiera le HTML réellement servi.
+
+**Tech Stack:** Next.js 16 Metadata API, TypeScript, Playwright, Jest, ESLint.
+
+---
+
+### Task 1: Couvrir puis modifier le titre de la page d’accueil
+
+**Files:**
+- Modify: `lib/site.ts`
+- Create: `tests/site-metadata.test.ts`
+- Modify: `tests/playwright/metadata-sociale.spec.ts`
+- Modify: `app/layout.tsx:34-69`
+
+- [ ] **Step 1: Lire la documentation Next.js 16 installée**
+
+Lire `node_modules/next/dist/docs/01-app/01-getting-started/14-metadata-and-og-images.md`, en particulier la section « Static metadata », et confirmer que l’export `metadata` du layout reste l’API adaptée.
+
+- [ ] **Step 2: Écrire le test unitaire en échec**
+
+Créer `tests/site-metadata.test.ts` :
+
+```ts
+import { HOME_PAGE_TITLE } from "@/lib/site";
+
+describe("métadonnées de la page d'accueil", () => {
+  it("cible l'opérateur télécom DOM dans une longueur SEO maîtrisée", () => {
+    expect(HOME_PAGE_TITLE).toBe(
+      "Opérateur de services télécom DOM | E2I VoIP",
+    );
+    expect(HOME_PAGE_TITLE.startsWith("Opérateur de services télécom DOM")).toBe(true);
+    expect(HOME_PAGE_TITLE.length).toBeLessThanOrEqual(60);
+  });
+});
+```
+
+- [ ] **Step 3: Vérifier l’échec du test unitaire**
+
+Run: `npm test -- tests/site-metadata.test.ts --runInBand`
+
+Résultat attendu : échec TypeScript/Jest car `HOME_PAGE_TITLE` n’est pas encore exporté par `lib/site.ts`.
+
+- [ ] **Step 4: Centraliser le titre dans la source de vérité SEO**
+
+Ajouter à `lib/site.ts` :
+
+```ts
+/** Titre SEO de la page d'accueil, partagé avec les métadonnées sociales. */
+export const HOME_PAGE_TITLE =
+  "Opérateur de services télécom DOM | E2I VoIP";
+```
+
+- [ ] **Step 5: Vérifier le test unitaire**
+
+Run: `npm test -- tests/site-metadata.test.ts --runInBand`
+
+Résultat attendu : `1 passed` et aucun échec.
+
+- [ ] **Step 6: Écrire le test Playwright en échec**
+
+Étendre le test existant afin de vérifier les trois sorties réellement rendues :
+
+```ts
+import { expect, test } from "@playwright/test";
+
+const HOME_TITLE = "Opérateur de services télécom DOM | E2I VoIP";
+
+test("la page d'accueil expose ses métadonnées sociales", async ({ page }) => {
+  await page.goto("/");
+
+  await expect(page).toHaveTitle(HOME_TITLE);
+  await expect(page.locator('meta[property="og:title"]')).toHaveAttribute(
+    "content",
+    HOME_TITLE,
+  );
+  await expect(page.locator('meta[name="twitter:title"]')).toHaveAttribute(
+    "content",
+    HOME_TITLE,
+  );
+
+  const openGraphImage = page.locator('meta[property="og:image"]');
+  await expect(openGraphImage).toHaveAttribute(
+    "content",
+    "https://www.e2i-voip.com/images/e2i-voip-partage.png",
+  );
+  await expect(page.locator('meta[property="og:image:width"]')).toHaveAttribute(
+    "content",
+    "1200",
+  );
+  await expect(page.locator('meta[property="og:image:height"]')).toHaveAttribute(
+    "content",
+    "630",
+  );
+  await expect(page.locator('meta[name="twitter:image"]')).toHaveAttribute(
+    "content",
+    "https://www.e2i-voip.com/images/e2i-voip-partage.png",
+  );
+});
+```
+
+- [ ] **Step 7: Libérer le port 3000 et vérifier l’échec Playwright**
+
+Arrêter tout serveur de développement actif, puis exécuter :
+
+```bash
+lsof -ti :3000 | xargs kill -9 2>/dev/null || true
+npx playwright test tests/playwright/metadata-sociale.spec.ts
+```
+
+Résultat attendu : échec sur le titre actuel `E2I VoIP - Solutions de téléphonie IP professionnelles`.
+
+- [ ] **Step 8: Appliquer le titre validé aux métadonnées statiques**
+
+Dans `app/layout.tsx`, importer `HOME_PAGE_TITLE` avec `SITE_URL` et `SITE_NAME`, puis remplacer uniquement les trois titres de la page d’accueil :
+
+```ts
+import { HOME_PAGE_TITLE, SITE_URL, SITE_NAME } from "@/lib/site";
+```
+
+```ts
+title: {
+  default: HOME_PAGE_TITLE,
+  template: `%s | ${SITE_NAME}`,
+},
+```
+
+```ts
+openGraph: {
+  title: HOME_PAGE_TITLE,
+  description:
+    "Solutions de téléphonie IP professionnelles pour optimiser vos communications d'entreprise.",
+  type: "website",
+  locale: "fr_FR",
+  url: SITE_URL,
+  siteName: SITE_NAME,
+  images: [
+    {
+      url: "/images/e2i-voip-partage.png",
+      width: 1200,
+      height: 630,
+      alt: "E2I VoIP — Opérateur de services télécom, spécialiste des DOM",
+    },
+  ],
+},
+```
+
+```ts
+twitter: {
+  card: "summary_large_image",
+  title: HOME_PAGE_TITLE,
+  description:
+    "Solutions de téléphonie IP professionnelles pour optimiser vos communications d'entreprise.",
+  images: ["/images/e2i-voip-partage.png"],
+},
+```
+
+- [ ] **Step 9: Relancer le test ciblé**
+
+Run: `npx playwright test tests/playwright/metadata-sociale.spec.ts`
+
+Résultat attendu : `1 passed` et aucun échec.
+
+- [ ] **Step 10: Vérifier qu’un titre interne conserve son suffixe**
+
+Run: `npx playwright test tests/playwright/metadata-sociale.spec.ts tests/playwright/blog-seo.spec.ts`
+
+Résultat attendu : toutes les assertions passent ; les métadonnées propres au blog restent inchangées.
+
+- [ ] **Step 11: Committer le changement fonctionnel**
+
+```bash
+git add app/layout.tsx lib/site.ts tests/site-metadata.test.ts tests/playwright/metadata-sociale.spec.ts
+git commit -m "feat(seo): cibler le titre sur l’opérateur télécom DOM"
+```
+
+### Task 2: Documenter la décision SEO
+
+**Files:**
+- Modify: `docs/ADR.md`
+- Modify: `docs/roadmap.md`
+
+- [ ] **Step 1: Ajouter l’entrée ADR en tête de l’historique**
+
+Ajouter après `## Historique` :
+
+```md
+### 2026-08-21 — Titre SEO de la page d’accueil ciblé sur les DOM
+
+- **Contexte** : le titre de la page d’accueil décrivait des solutions de téléphonie IP professionnelles sans exprimer le positionnement différenciant d’E2I VoIP ni sa zone prioritaire.
+- **Décision** : remplacer le titre HTML par « Opérateur de services télécom DOM | E2I VoIP » et aligner `og:title` ainsi que `twitter:title`. Les titres spécifiques des pages internes et la description SEO restent inchangés.
+- **Conséquences** : l’intention « opérateur télécom DOM » apparaît dès le début du titre, la marque reste identifiable et les aperçus sociaux emploient le même message.
+- **Tests associés** : `tests/playwright/metadata-sociale.spec.ts` vérifie le `<title>`, `og:title` et `twitter:title` rendus sur la page d’accueil.
+```
+
+- [ ] **Step 2: Mettre à jour la roadmap disponible**
+
+Ajouter à la fin des notes de maintenance de `docs/roadmap.md` :
+
+```md
+> **Optimisation SEO (2026-08-21)** : titre de la page d’accueil recentré sur le positionnement « Opérateur de services télécom DOM », avec métadonnées sociales alignées. Voir `docs/ADR.md`.
+```
+
+Ne pas créer `.planning/ROADMAP.md` ou `.planning/STATE.md` : ces chemins sont documentés comme source de vérité historique mais sont absents de la branche `dev` actuelle.
+
+- [ ] **Step 3: Contrôler la documentation**
+
+Run: `git diff --check`
+
+Résultat attendu : sortie vide et code de retour 0.
+
+- [ ] **Step 4: Committer la documentation**
+
+```bash
+git add docs/ADR.md docs/roadmap.md docs/superpowers/plans/2026-08-21-titre-seo-operateur-telecom-dom.md
+git commit -m "docs(seo): documenter le titre opérateur télécom DOM"
+```
+
+### Task 3: Validation complète et préparation de la PR
+
+**Files:**
+- Verify: `app/layout.tsx`
+- Verify: `lib/site.ts`
+- Verify: `tests/site-metadata.test.ts`
+- Verify: `tests/playwright/metadata-sociale.spec.ts`
+- Verify: `docs/ADR.md`
+- Verify: `docs/roadmap.md`
+
+- [ ] **Step 1: Repartir d’un serveur propre**
+
+Arrêter le serveur actif et libérer le port :
+
+```bash
+lsof -ti :3000 | xargs kill -9 2>/dev/null || true
+```
+
+- [ ] **Step 2: Lancer les six contrôles bloquants**
+
+Run: `npm run validate`
+
+Résultat attendu : ESLint, TypeScript, Jest avec couverture, Playwright, audit de sécurité et build réussissent tous. Un seul échec bloque la PR.
+
+- [ ] **Step 3: Vérifier l’hydratation CSS**
+
+Run: `npm run dev`
+
+Ouvrir `/`, contrôler le terminal et la console navigateur, puis arrêter le serveur. Résultat attendu : aucun warning ou erreur CSS/hydratation.
+
+- [ ] **Step 4: Vérifier le diff final**
+
+```bash
+git status --short
+git diff dev...HEAD --check
+git diff dev...HEAD -- app/layout.tsx tests/playwright/metadata-sociale.spec.ts docs/ADR.md docs/roadmap.md
+```
+
+Résultat attendu : aucun fichier inattendu, aucun défaut d’espacement et uniquement le périmètre validé.
+
+- [ ] **Step 5: Pousser la branche et ouvrir la PR vers `dev`**
+
+```bash
+git push -u origin feat/titre-seo-operateur-telecom-dom
+gh pr create --base dev --title "feat(seo): cibler la page d’accueil sur l’opérateur télécom DOM" --body-file /tmp/e2ivoip-pr-titre-seo.md
+```
+
+Le corps de PR doit contenir l’objectif, les changements, les résultats Jest et Playwright, l’entrée ADR, ainsi que les risques : délai de réindexation Google et caches des plateformes sociales. Ne pas fusionner la PR.

--- a/docs/superpowers/specs/2026-08-21-titre-seo-operateur-telecom-dom-design.md
+++ b/docs/superpowers/specs/2026-08-21-titre-seo-operateur-telecom-dom-design.md
@@ -1,0 +1,36 @@
+# Titre SEO — opérateur télécom DOM
+
+## Objectif
+
+Renforcer le positionnement de la page d’accueil sur l’intention
+« opérateur télécom DOM » avec un titre clair, concis et cohérent sur les
+supports de partage.
+
+## Décision
+
+Le titre retenu est :
+
+> Opérateur de services télécom DOM | E2I VoIP
+
+Cette formulation place le sujet principal et la zone géographique avant la
+marque. Sa longueur reste adaptée à l’affichage dans les résultats de recherche.
+
+## Périmètre
+
+- Remplacer le titre par défaut de la page d’accueil dans les métadonnées Next.js.
+- Utiliser le même texte pour `openGraph.title` et `twitter.title`.
+- Ne pas modifier la description SEO, le H1 ou le contenu visible.
+- Ne pas modifier les titres propres aux pages internes.
+
+## Validation
+
+- Ajouter un test unitaire vérifiant le titre HTML, Open Graph et Twitter.
+- Vérifier que les pages internes conservent leur mécanisme de titre existant.
+- Exécuter `npm run validate`, dont les contrôles Jest et Playwright.
+- Vérifier l’absence d’erreur ou de warning d’hydratation au démarrage local.
+
+## Documentation et livraison
+
+- Ajouter la décision dans `docs/ADR.md`.
+- Mettre à jour la roadmap et l’état d’implémentation.
+- Livrer sur une branche dédiée via une PR vers `dev`, sans fusion automatique.

--- a/lib/site.ts
+++ b/lib/site.ts
@@ -13,3 +13,7 @@ export const SITE_URL = (
 
 /** Nom commercial officiel, réutilisé dans les métadonnées et le JSON-LD. */
 export const SITE_NAME = "E2I VoIP";
+
+/** Titre SEO de la page d'accueil, partagé avec les métadonnées sociales. */
+export const HOME_PAGE_TITLE =
+  "Opérateur de services télécom DOM | E2I VoIP";

--- a/tests/playwright/metadata-sociale.spec.ts
+++ b/tests/playwright/metadata-sociale.spec.ts
@@ -1,15 +1,33 @@
 import { expect, test } from "@playwright/test";
 
-test("la page d'accueil expose l'image de partage E2I VoIP", async ({ page }) => {
+const HOME_TITLE = "Opérateur de services télécom DOM | E2I VoIP";
+
+test("la page d'accueil expose ses métadonnées sociales", async ({ page }) => {
   await page.goto("/");
+
+  await expect(page).toHaveTitle(HOME_TITLE);
+  await expect(page.locator('meta[property="og:title"]')).toHaveAttribute(
+    "content",
+    HOME_TITLE,
+  );
+  await expect(page.locator('meta[name="twitter:title"]')).toHaveAttribute(
+    "content",
+    HOME_TITLE,
+  );
 
   const openGraphImage = page.locator('meta[property="og:image"]');
   await expect(openGraphImage).toHaveAttribute(
     "content",
     "https://www.e2i-voip.com/images/e2i-voip-partage.png",
   );
-  await expect(page.locator('meta[property="og:image:width"]')).toHaveAttribute("content", "1200");
-  await expect(page.locator('meta[property="og:image:height"]')).toHaveAttribute("content", "630");
+  await expect(page.locator('meta[property="og:image:width"]')).toHaveAttribute(
+    "content",
+    "1200",
+  );
+  await expect(page.locator('meta[property="og:image:height"]')).toHaveAttribute(
+    "content",
+    "630",
+  );
   await expect(page.locator('meta[name="twitter:image"]')).toHaveAttribute(
     "content",
     "https://www.e2i-voip.com/images/e2i-voip-partage.png",

--- a/tests/site-metadata.test.ts
+++ b/tests/site-metadata.test.ts
@@ -1,0 +1,11 @@
+import { HOME_PAGE_TITLE } from "@/lib/site";
+
+describe("métadonnées de la page d'accueil", () => {
+  it("cible l'opérateur télécom DOM dans une longueur SEO maîtrisée", () => {
+    expect(HOME_PAGE_TITLE).toBe(
+      "Opérateur de services télécom DOM | E2I VoIP",
+    );
+    expect(HOME_PAGE_TITLE.startsWith("Opérateur de services télécom DOM")).toBe(true);
+    expect(HOME_PAGE_TITLE.length).toBeLessThanOrEqual(60);
+  });
+});


### PR DESCRIPTION
## Objectif

Positionner la page d’accueil sur la requête « opérateur télécom DOM » avec un titre unique et cohérent dans le HTML, Open Graph et Twitter.

## Changements

- `lib/site.ts` : nouvelle constante `HOME_PAGE_TITLE` = « Opérateur de services télécom DOM | E2I VoIP » (44 caractères), centralisée dans la source de vérité SEO existante.
- `app/layout.tsx` : les trois titres de la page d’accueil (`title.default`, `openGraph.title`, `twitter.title`) consomment `HOME_PAGE_TITLE`. Le `template: "%s | E2I VoIP"` est inchangé, donc les titres des pages internes conservent leur suffixe marque. Les descriptions et l’image de partage sont inchangées.
- `tests/site-metadata.test.ts` : test unitaire couvrant la règle SEO (valeur exacte, intention en tête, longueur ≤ 60 caractères).
- `tests/playwright/metadata-sociale.spec.ts` : le test existant vérifie désormais aussi `<title>`, `og:title` et `twitter:title` réellement rendus, en plus des métadonnées d’image.
- `docs/ADR.md` + `docs/roadmap.md` : décision documentée.

## Résultats de tests

| Contrôle | Résultat |
| --- | --- |
| ESLint | ✅ |
| TypeScript (`tsc --noEmit`) | ✅ |
| Jest | ✅ 439 tests / 68 suites |
| Playwright `metadata-sociale.spec.ts` | ✅ 1 passed |
| Audit sécurité (`npm audit --audit-level=high`) | ✅ 0 vulnérabilité |
| Build (`next build`) | ✅ |

Vérification manuelle sur `npm run dev` : `<title>`, `og:title` et `twitter:title` rendent tous les trois « Opérateur de services télécom DOM | E2I VoIP », sans warning console ni erreur d’hydratation/CSS.

### Point d’attention : `npm run validate` incomplet

L’étape Playwright échoue sur 9 tests du blog (`blog-seo.spec.ts`, `blog-hubspot-images.spec.ts`) parce que le `HUBSPOT_ACCESS_TOKEN` de `.env.local` renvoie **401 INVALID_AUTHENTICATION**. Ces mêmes tests échouent à l’identique sur `dev` sans les modifications de cette branche : le blocage est antérieur et sans lien avec ce changement. Les cinq autres contrôles du pipeline passent. À rejouer une fois le token renouvelé.

## Risques

- **Réindexation Google** : le nouveau titre met généralement quelques jours à quelques semaines à apparaître en SERP. Google peut aussi réécrire le titre affiché s’il le juge peu pertinent pour la requête.
- **Caches sociaux** : LinkedIn, Facebook et X conservent les aperçus précédents. Prévoir un rafraîchissement manuel via leurs outils de debug pour les URL déjà partagées.

## ADR

Entrée `2026-08-21 — Titre SEO de la page d’accueil ciblé sur les DOM` ajoutée dans `docs/ADR.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015FKBHs7XiQ3Y3xKLw8J6jA
